### PR TITLE
Add faraday_middleware class

### DIFF
--- a/manifests/faraday_middleware.pp
+++ b/manifests/faraday_middleware.pp
@@ -1,0 +1,6 @@
+class archive::faraday_middleware {
+  package { 'faraday_middleware':
+    ensure   => installed,
+    provider => gem,
+  }
+}


### PR DESCRIPTION
So this is mildly annoying.

faraday_middleware is as the README notes present on the server, but this doesn't help a lot because it's the provider that needs it :)

This is another solution I don't love, but it lets the user optionally call this class and get the gem. If they want to manage it some other way, rock on.
