### PR TITLE
Fix order of options to tar

### DIFF
--- a/lib/puppet_x/bodeco/archive.rb
+++ b/lib/puppet_x/bodeco/archive.rb
@@ -63,16 +63,16 @@ module PuppetX
         else
           case @file
           when /\.tar$/
-            opt = parse_flags('xf', options, 'tar')
-            "tar #{opt} #{@file}"
+            opt = parse_flags("xf #{@file} ", options, 'tar')
+            "tar #{opt}"
           when /(\.tgz|\.tar\.gz)$/
             if Facter.value(:osfamily) == 'Solaris'
               gunzip_opt = parse_flags('-dc', options, 'gunzip')
               tar_opt = parse_flags('xf', options, 'tar')
               "gunzip #{gunzip_opt} #{@file} | tar #{tar_opt} -"
             else
-              opt = parse_flags('xzf', options, 'tar')
-              "tar #{opt} #{@file}"
+              opt = parse_flags("xzf #{@file} ", options, 'tar')
+              "tar #{opt}"
             end
           when /(\.zip|\.war|\.jar)$/
             opt = parse_flags('-o', options, 'zip')


### PR DESCRIPTION
The order of options being passed to tar isn't quite correct. The file to be extracted is a actually a parameter to the "f" option in the command line being passed. I've changed the order and added a space to the existing parameters so that extra options passed as extract_flags do not get appended to the end of the filename.

There are a few cases where this will still cause problems, but it's better than the current code, as passing _any_ extract_flags will currently break tar. 
