### PR TITLE
Fix custom flag not behaving correctly.

### DIFF
--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -78,8 +78,8 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:extract_flags) do
-    desc "custom extract command."
-    defaultto('')
+    desc "custom extract options, this replaces the default flags. A string such as 'xvf' for a tar file would replace the default xf flag. A hash is useful when custom flags are needed for different platforms. {'tar' => 'xzf', '7z' => 'x -aot'}."
+    defaultto(:undef)
   end
 
   newparam(:path) do

--- a/lib/puppet_x/bodeco/archive.rb
+++ b/lib/puppet_x/bodeco/archive.rb
@@ -18,7 +18,7 @@ module PuppetX
       end
 
       def root_dir
-        if Facter.value('osfamily') == 'windows'
+        if Facter.value(:osfamily) == 'windows'
           'C:\\'
         else
           '/'
@@ -57,7 +57,7 @@ module PuppetX
       end
 
       def command(options)
-        if Facter.value('osfamily') == 'windows'
+        if Facter.value(:osfamily) == 'windows'
           opt = parse_flags('x -aoa', options, '7z')
           "#{win_7zip} #{opt} #{@file}"
         else
@@ -85,10 +85,12 @@ module PuppetX
 
       def parse_flags(default, options, command=nil)
         case options
+        when :undef
+          default
         when ::String
-          "#{default}#{options}"
+          options
         when ::Hash
-          "#{default}#{options[command]}"
+          options[command]
         else
           raise ArgumentError, "Invalid options for command #{command}: #{options.inspect}"
         end

--- a/spec/unit/puppet/type/archive_spec.rb
+++ b/spec/unit/puppet/type/archive_spec.rb
@@ -14,6 +14,7 @@ describe Puppet::Type::type(:archive) do
     resource[:checksum_type].should eq :none
     resource[:checksum_verify].should eq :true
     resource[:path].should eq '/tmp/example.zip'
+    resource[:extract_flags].should eq :undef
   end
 
   it 'verify resource[:path] is absolute filepath' do

--- a/spec/unit/puppet_x/bodeco/archive_spec.rb
+++ b/spec/unit/puppet_x/bodeco/archive_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'puppet_x/bodeco/archive'
+
+describe PuppetX::Bodeco::Archive do
+  let(:zipfile){
+    File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'files', 'test.zip'))
+  }
+
+  it '#checksum' do
+    Dir.mktmpdir do |dir|
+      tempfile = File.join(dir, 'test.zip')
+      FileUtils.cp(zipfile, tempfile)
+
+      archive = PuppetX::Bodeco::Archive.new(tempfile)
+      expect(archive.checksum(:none)).to be nil
+      expect(archive.checksum(:md5)).to eq '557e2ebb67b35d1fddff18090b6bc26b'
+      expect(archive.checksum(:sha1)).to eq '377ec712d7fdb7266221db3441e3af2055448ead'
+    end
+  end
+
+  it '#parse_flags' do
+    archive = PuppetX::Bodeco::Archive.new('test.tar.gz')
+    expect(archive.send(:parse_flags, 'xf', :undef, 'tar')).to eq 'xf'
+    expect(archive.send(:parse_flags, 'xf', 'xvf', 'tar')).to eq 'xvf'
+    expect(archive.send(:parse_flags, 'xf', {'tar' => 'xzf', '7z' => '-y x'}, 'tar')).to eq 'xzf'
+  end
+
+  it '#command on RedHat' do
+    Facter.stubs(:value).with(:osfamily).returns 'RedHat'
+
+    tar = PuppetX::Bodeco::Archive.new('test.tar.gz')
+    expect(tar.send(:command, :undef)).to eq 'tar xzf test.tar.gz'
+    expect(tar.send(:command, 'xvf')).to eq 'tar xvf test.tar.gz'
+
+    zip = PuppetX::Bodeco::Archive.new('test.zip')
+    expect(zip.send(:command, :undef)).to eq 'unzip -o test.zip'
+    expect(zip.send(:command, '-a')).to eq 'unzip -a test.zip'
+  end
+
+  it '#command on Windows' do
+    Facter.stubs(:value).with(:osfamily).returns 'windows'
+
+    tar = PuppetX::Bodeco::Archive.new('test.tar.gz')
+    tar.stubs(:win_7zip).returns('7z.exe')
+    expect(tar.send(:command, :undef)).to eq '7z.exe x -aoa test.tar.gz'
+    expect(tar.send(:command, 'x -aot')).to eq '7z.exe x -aot test.tar.gz'
+
+    zip = PuppetX::Bodeco::Archive.new('test.zip')
+    zip.stubs(:win_7zip).returns('7z.exe')
+    expect(zip.send(:command, :undef)).to eq '7z.exe x -aoa test.zip'
+  end
+end


### PR DESCRIPTION
Instead of prefixing or appending the option flags, this allows the user
to specify the full option flag between the extract command and
filename. So instead of the default 'xf' flag, the user should specify
'xvzf' instead of trying to guess where to add the 'vz' flags.
