### PR TITLE
Support a variety of common formats for remote checksums

### DIFF
--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -67,7 +67,14 @@ Puppet::Type.type(:archive).provide(:ruby) do
   end
 
   def remote_checksum
-    @remote_checksum ||= PuppetX::Bodeco::Util.content(resource[:checksum_url], :username => resource[:username], :password => resource[:password], :cookie => resource[:cookie]) if resource[:checksum_url]
+    @remote_checksum ||= begin
+      PuppetX::Bodeco::Util.content(
+        resource[:checksum_url],
+        :username => resource[:username],
+        :password => resource[:password],
+        :cookie => resource[:cookie]
+      )[/\b[\da-f]{32,128}\b/i] if resource[:checksum_url]
+    end
   end
 
   # Private: See if local archive checksum matches.

--- a/spec/support/shared_behaviour.rb
+++ b/spec/support/shared_behaviour.rb
@@ -15,6 +15,39 @@ RSpec.shared_examples 'an archive provider' do |provider_class|
       File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'files', 'test.zip'))
     end
 
+    describe '#remote_checksum' do
+      subject { provider.remote_checksum }
+      let(:url) { nil }
+      let(:remote_hash) { nil }
+      before(:each) do
+        resource[:checksum_url] = url if url
+        allow(PuppetX::Bodeco::Util).to receive(:content)
+          .with(url, any_args).and_return(remote_hash)
+      end
+      context 'unset' do
+        it { is_expected.to be_nil }
+      end
+      context 'with a url' do
+        let(:url) { 'http://example.com/checksum' }
+        context 'responds with hash' do
+          let(:remote_hash) { 'a0c38e1aeb175201b0dacd65e2f37e187657050a' }
+          it { is_expected.to eq('a0c38e1aeb175201b0dacd65e2f37e187657050a') }
+        end
+        context 'responds with hash and newline' do
+          let(:remote_hash) { "a0c38e1aeb175201b0dacd65e2f37e187657050a\n" }
+          it { is_expected.to eq('a0c38e1aeb175201b0dacd65e2f37e187657050a') }
+        end
+        context 'responds with `sha1sum README.md` output' do
+          let(:remote_hash) { "a0c38e1aeb175201b0dacd65e2f37e187657050a  README.md\n" }
+          it { is_expected.to eq('a0c38e1aeb175201b0dacd65e2f37e187657050a') }
+        end
+        context 'responds with `openssl dgst -hex -sha256 README.md` output' do
+          let(:remote_hash) { "SHA256(README.md)= 8fa3f0ff1f2557657e460f0f78232679380a9bcdb8670e3dcb33472123b22428\n" }
+          it { is_expected.to eq('8fa3f0ff1f2557657e460f0f78232679380a9bcdb8670e3dcb33472123b22428') }
+        end
+      end
+    end
+
     it '#checksum?' do
       Dir.mktmpdir do |dir|
         resource[:path] = File.join(dir, resource[:filename])


### PR DESCRIPTION
Fixes #72 

This commit adds tests for the existing remote_checksum code, and then expands support to cover a few common ways of generating checksums - as shown in the tests.

This might be a bit overkill, I'm happy to remove some of the fancier handling if desired.

It's annoying that `sha1sum` puts the hash at the front, but `openssl` puts the hash at the end.