### PR TITLE
Only use the faraday provider when the faraday_middleware gem is installed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :test do
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec',                                                      :require => false
   gem 'puppet-blacksmith',                                          :require => false
-  gem 'rubocop',                                                    :require => false
+  gem 'rubocop', '0.35.0',                                          :require => false
   gem 'puppetlabs_spec_helper',                                     :require => false
   gem 'puppet-lint-absolute_classname-check',                       :require => false
   gem 'puppet-lint-leading_zero-check',                             :require => false

--- a/lib/puppet/provider/archive/faraday.rb
+++ b/lib/puppet/provider/archive/faraday.rb
@@ -8,6 +8,8 @@ rescue LoadError
 end
 
 Puppet::Type.type(:archive).provide(:faraday, :parent => :ruby) do
+  confine :feature => :faraday_middleware
+
   def download(filepath)
     PuppetX::Bodeco::Util.download(resource[:source], filepath, :username => resource[:username], :password => resource[:password], :cookie => resource[:cookie], :proxy_server => resource[:proxy_server], :proxy_type => resource[:proxy_type])
   end


### PR DESCRIPTION
On systems where wget is installed, but curl isn't the following warning occurs:
```
  Warning: Found multiple default providers for archive: faraday, wget; using faraday
```
Another failure happens later on when the faraday_middleware gem isn't installed:
```
  no such file to load -- faraday_middleware
```

Resolved this by confining the faraday provider so it only
gets used when the faraday_middleware gem is installed