### PR TITLE
Support xz format

### DIFF
--- a/lib/puppet_x/bodeco/archive.rb
+++ b/lib/puppet_x/bodeco/archive.rb
@@ -93,6 +93,10 @@ module PuppetX
               opt = parse_flags('xjf', options, 'tar')
               "tar #{opt} #{@file}"
             end
+          when /(\.txz|\.tar\.xz)$/
+            unxz_opt = parse_flags('-dc', options, 'unxz')
+            tar_opt = parse_flags('xf', options, 'tar')
+            "unxz #{unxz_opt} #{@file} | tar #{tar_opt} -"
           when /(\.zip|\.war|\.jar)$/
             opt = parse_flags('-o', options, 'zip')
             "unzip #{opt} #{@file}"

--- a/spec/unit/puppet_x/bodeco/archive_spec.rb
+++ b/spec/unit/puppet_x/bodeco/archive_spec.rb
@@ -34,6 +34,8 @@ describe PuppetX::Bodeco::Archive do
     tar = PuppetX::Bodeco::Archive.new('test.tar.bz2')
     expect(tar.send(:command, :undef)).to eq 'tar xjf test.tar.bz2'
     expect(tar.send(:command, 'xjf')).to eq 'tar xjf test.tar.bz2'
+    tar = PuppetX::Bodeco::Archive.new('test.tar.xz')
+    expect(tar.send(:command, :undef)).to eq 'unxz -dc test.tar.xz | tar xf -'
     zip = PuppetX::Bodeco::Archive.new('test.zip')
     expect(zip.send(:command, :undef)).to eq 'unzip -o test.zip'
     expect(zip.send(:command, '-a')).to eq 'unzip -a test.zip'


### PR DESCRIPTION
It should use unxz because old OS doesn't support `J` option of tar (e.g. Solaris 10, CentOS5, ...).