### PR TITLE
Add support for .gz

### DIFF
--- a/lib/puppet_x/bodeco/archive.rb
+++ b/lib/puppet_x/bodeco/archive.rb
@@ -97,6 +97,9 @@ module PuppetX
             unxz_opt = parse_flags('-dc', options, 'unxz')
             tar_opt = parse_flags('xf', options, 'tar')
             "unxz #{unxz_opt} #{@file} | tar #{tar_opt} -"
+          when /\.gz$/
+            opt = parse_flags('-d', options, 'gunzip')
+            "gunzip #{opt} #{@file}"
           when /(\.zip|\.war|\.jar)$/
             opt = parse_flags('-o', options, 'zip')
             "unzip #{opt} #{@file}"

--- a/spec/unit/puppet_x/bodeco/archive_spec.rb
+++ b/spec/unit/puppet_x/bodeco/archive_spec.rb
@@ -36,6 +36,8 @@ describe PuppetX::Bodeco::Archive do
     expect(tar.send(:command, 'xjf')).to eq 'tar xjf test.tar.bz2'
     tar = PuppetX::Bodeco::Archive.new('test.tar.xz')
     expect(tar.send(:command, :undef)).to eq 'unxz -dc test.tar.xz | tar xf -'
+    gunzip = PuppetX::Bodeco::Archive.new('test.gz')
+    expect(gunzip.send(:command, :undef)).to eq 'gunzip -d test.gz'
     zip = PuppetX::Bodeco::Archive.new('test.zip')
     expect(zip.send(:command, :undef)).to eq 'unzip -o test.zip'
     expect(zip.send(:command, '-a')).to eq 'unzip -a test.zip'


### PR DESCRIPTION
Add support for .gz, because not every file is being compressed using tar. 