### PR TITLE
Fixing tests failures on non-defined facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ class { 'archive':
 }
 
 ```
+
+Note: If you are writing a dependent module that include specs in it, you will
+need to set the puppetversion fact in your puppet-rspec tests. You can do that
+by adding it to the default facts of your spec/spec_helper.rb. Example:
+
+```
+RSpec.configure do |c|
+  c.default_facts = { :puppetversion => Puppet.version }
+end
+```
+
 ## Reference
 
 ### Classes

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,14 +1,6 @@
 # archive parameters
 class archive::params {
   case $::osfamily {
-    default: {
-      $path  = '/opt/staging'
-      $owner = '0'
-      $group = '0'
-      $mode  = '0640'
-      $seven_zip_name = undef
-      $seven_zip_provider = undef
-    }
     'Windows': {
       $path               = $::archive_windir
       $owner              = 'S-1-5-32-544' # Adminstrators
@@ -16,14 +8,24 @@ class archive::params {
       $mode               = '0640'
       $seven_zip_name     = '7zip'
       $seven_zip_provider = 'chocolatey'
+      if versioncmp($::puppetversion, '4.3.1') >= 0 {
+        $gem_provider = 'pe_gem'
+      } else {
+        $gem_provider = 'gem'
+      }
     }
-  }
-
-  if $::puppetversion =~ /Puppet Enterprise/ and $::osfamily != 'Windows' {
-    $gem_provider = 'pe_gem'
-  } elsif $::aio_agent_version {
-    $gem_provider = 'puppet_gem'
-  } else {
-    $gem_provider = 'gem'
+    default: {
+      $path  = '/opt/staging'
+      $owner = '0'
+      $group = '0'
+      $mode  = '0640'
+      $seven_zip_name = undef
+      $seven_zip_provider = undef
+      if $::puppetversion =~ /Puppet Enterprise/ or versioncmp($::puppetversion, '4.0.0') >= 0 {
+        $gem_provider = 'pe_gem'
+      } else {
+        $gem_provider = 'gem'
+      }
+    }
   }
 }

--- a/spec/classes/archive_spec.rb
+++ b/spec/classes/archive_spec.rb
@@ -17,8 +17,16 @@ describe 'archive' do
     it { is_expected.to_not contain_package('7zip') }
   end
 
+  context 'RHEL Puppet 4.0.0 opensource' do
+    let(:facts) { { :osfamily => 'RedHat', :puppetversion => '4.0.0' } }
+
+    it { is_expected.to contain_package('faraday').with_provider('pe_gem') }
+    it { is_expected.to contain_package('faraday_middleware').with_provider('pe_gem') }
+    it { is_expected.to_not contain_package('7zip') }
+  end
+
   context 'Windows Puppet opensource' do
-    let(:facts) { { :osfamily => 'Windows', :puppetversion => '3.7.3' } }
+    let(:facts) { { :osfamily => 'Windows', :archive_windir => 'C:/staging', :puppetversion => '3.7.3' } }
 
     it { is_expected.to contain_package('faraday').with_provider('gem') }
     it { is_expected.to contain_package('faraday_middleware').with_provider('gem') }
@@ -28,8 +36,19 @@ describe 'archive' do
     end
   end
 
+  context 'Windows Puppet 4.3.1 opensource' do
+    let(:facts) { { :osfamily => 'Windows', :archive_windir => 'C:/staging', :puppetversion => '4.3.1' } }
+
+    it { is_expected.to contain_package('faraday').with_provider('pe_gem') }
+    it { is_expected.to contain_package('faraday_middleware').with_provider('pe_gem') }
+    it do
+      should contain_package('7zip').with(:name     => '7zip',
+                                          :provider => 'chocolatey',)
+    end
+  end
+
   context 'Windows Puppet Enterprise' do
-    let(:facts) { { :osfamily => 'Windows', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)' } }
+    let(:facts) { { :osfamily => 'Windows', :archive_windir => 'C:/staging', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)' } }
 
     it { is_expected.to contain_package('faraday').with_provider('gem') }
     it { is_expected.to contain_package('faraday_middleware').with_provider('gem') }
@@ -40,7 +59,7 @@ describe 'archive' do
   end
 
   context 'with 7zip package' do
-    let(:facts) { { :osfamily => 'Windows', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)' } }
+    let(:facts) { { :osfamily => 'Windows', :archive_windir => 'C:/staging', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)' } }
 
     let(:params) do
       {
@@ -60,7 +79,7 @@ describe 'archive' do
   end
 
   context 'without 7zip' do
-    let(:facts) { { :osfamily => 'Windows', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)' } }
+    let(:facts) { { :osfamily => 'Windows', :archive_windir => 'C:/staging', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)' } }
 
     let(:params) do
       {

--- a/spec/unit/facter/archive_windir_spec.rb
+++ b/spec/unit/facter/archive_windir_spec.rb
@@ -1,0 +1,26 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+require 'facter/archive_windir'
+
+describe 'archive_windir fact specs', :type => :fact do
+  before { Facter.clear }
+  after { Facter.clear }
+
+  context 'RedHat' do
+    before :each do
+      Facter.fact(:osfamily).stubs(:value).returns 'RedHat'
+    end
+    it 'should be nil on RedHat' do
+      expect(Facter.fact(:archive_windir).value).to be_nil
+    end
+  end
+
+  context 'Windows' do
+    before :each do
+      Facter.fact(:osfamily).stubs(:value).returns 'windows'
+    end
+    it 'should default to C:\\staging on windows' do
+      expect(Facter.fact(:archive_windir).value).to eq('C:\\staging')
+    end
+  end
+end


### PR DESCRIPTION
Hi,

Currently the tests are failing on testing of undefined facts when compiling with STRICT_VARIABLES:
```
Undefined variable "::aio_agent_version"; Undefined variable "aio_agent_version" at /home/travis/build/voxpupuli/puppet-archive/spec/fixtures/modules/archive/manifests/params.pp:24 on node testing-worker-linux-docker-bc362139-3367-linux-14.prod.travis-ci.org
```
and:
```
Undefined variable "::archive_windir"; Undefined variable "archive_windir" at /home/travis/build/voxpupuli/puppet-archive/spec/fixtures/modules/archive/manifests/params.pp:13 on node testing-worker-linux-docker-bc362139-3367-linux-14.prod.travis-ci.org
```

Example: https://travis-ci.org/voxpupuli/puppet-archive/jobs/109740076

To fix this we can use getvar. This PR fixes that.

Thanks
Joseph