### PR TITLE
Adding more Puppet versions to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
   - rvm: 2.1.6
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.1.6
+    env: PUPPET_VERSION="~> 3.5" STRICT_VARIABLES="yes" CHECK=test
+  - rvm: 2.1.6
+    env: PUPPET_VERSION="~> 3.8" STRICT_VARIABLES="yes" FUTURE_PARSER=yes CHECK=test
+  - rvm: 2.1.6
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.2.3
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test


### PR DESCRIPTION
Hi,

There have been significant changes in several versions of Puppet 3.
It's a good practice to test the different versions. Also adding the support of the future parser that brings also significant changes.

For example, when I build a dependent package with Travis on puppet 3.5 to 3.8 I get:
```
     Puppet::Error:
       Undefined variable "::puppetversion"; Undefined variable "puppetversion" at /home/travis/build/tubemogul/puppet-aerospike/spec/fixtures/modules/archive/manifests/params.pp:22 on node testing-worker-linux-docker-94746611-3371-linux-6.prod.travis-ci.org
```
I'm looking for a fix for the generated error and I'll add it to this PR.
For now, if you could just tell me if you'd be ok to add those environments to the travis builds, it would be awesome.

Thanks! :)
Joseph
