### PR TITLE
Fixing the provider name bug introduced in #117

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class archive::params {
       $seven_zip_name     = '7zip'
       $seven_zip_provider = 'chocolatey'
       if versioncmp($::puppetversion, '4.3.1') >= 0 {
-        $gem_provider = 'pe_gem'
+        $gem_provider = 'puppet_gem'
       } else {
         $gem_provider = 'gem'
       }
@@ -21,8 +21,10 @@ class archive::params {
       $mode  = '0640'
       $seven_zip_name = undef
       $seven_zip_provider = undef
-      if $::puppetversion =~ /Puppet Enterprise/ or versioncmp($::puppetversion, '4.0.0') >= 0 {
+      if $::puppetversion =~ /Puppet Enterprise/ {
         $gem_provider = 'pe_gem'
+      } elsif versioncmp($::puppetversion, '4.0.0') >= 0 {
+        $gem_provider = 'puppet_gem'
       } else {
         $gem_provider = 'gem'
       }

--- a/spec/classes/archive_spec.rb
+++ b/spec/classes/archive_spec.rb
@@ -20,8 +20,8 @@ describe 'archive' do
   context 'RHEL Puppet 4.0.0 opensource' do
     let(:facts) { { :osfamily => 'RedHat', :puppetversion => '4.0.0' } }
 
-    it { is_expected.to contain_package('faraday').with_provider('pe_gem') }
-    it { is_expected.to contain_package('faraday_middleware').with_provider('pe_gem') }
+    it { is_expected.to contain_package('faraday').with_provider('puppet_gem') }
+    it { is_expected.to contain_package('faraday_middleware').with_provider('puppet_gem') }
     it { is_expected.to_not contain_package('7zip') }
   end
 
@@ -39,8 +39,8 @@ describe 'archive' do
   context 'Windows Puppet 4.3.1 opensource' do
     let(:facts) { { :osfamily => 'Windows', :archive_windir => 'C:/staging', :puppetversion => '4.3.1' } }
 
-    it { is_expected.to contain_package('faraday').with_provider('pe_gem') }
-    it { is_expected.to contain_package('faraday_middleware').with_provider('pe_gem') }
+    it { is_expected.to contain_package('faraday').with_provider('puppet_gem') }
+    it { is_expected.to contain_package('faraday_middleware').with_provider('puppet_gem') }
     it do
       should contain_package('7zip').with(:name     => '7zip',
                                           :provider => 'chocolatey',)


### PR DESCRIPTION
Hi,

I introduced a bug in #117 : I mixed up the name of the embedded gem provider for puppet >= 4. I put pe_gem instead of the new 'puppet_gem' http://docs.puppetlabs.com/puppet/4.0/reference/type.html#package-provider-puppet_gem.
pe_gem is the one coming from https://github.com/puppetlabs/puppetlabs-pe_gem which is deprecated in puppet 4.

This one fixes this error and fixes the related tests.

Sorry for that. :/
Thanks
Joseph