### PR TITLE
Revert "[blacksmith] Bump version to 0.4.5"

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -96,7 +96,7 @@
     }
   ],
   "name": "puppet-archive",
-  "version": "0.4.5",
+  "version": "0.4.4",
   "source": "https://github.com/puppet-community/puppet-archive",
   "author": "puppetcommunity",
   "license": "Apache-2.0",


### PR DESCRIPTION
This reverts commit 9087caf53c12aa5d70728ea003f97f33f91dc1ff.