### PR TITLE
open file in binary mode when writing downloaded content

### DIFF
--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -62,7 +62,7 @@ module PuppetX
 
       def download(uri, file_path, option = { :limit => FOLLOW_LIMIT })
         follow_redirect(uri, option) do |response|
-          File.open file_path, 'w' do |io|
+          File.open file_path, 'wb' do |io|
             response.read_body do |chunk|
               io.write chunk
             end


### PR DESCRIPTION
On Windows writing data to files in text mode will modify the resulting content
of the file, which causes the downloaded file to break. Add the binary flag to
the file mode to ensure there is no character conversion and the data is written
as-is.