### PR TITLE
voxpopuli/puppet-archive#142 Fix Cookie header double quotes on wget

### DIFF
--- a/lib/puppet/provider/archive/wget.rb
+++ b/lib/puppet/provider/archive/wget.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:archive).provide(:wget, :parent => :ruby) do
 
     params += optional_switch(resource[:username], ['--user=%s'])
     params += optional_switch(resource[:password], ['--password=%s'])
-    params += optional_switch(resource[:cookie], ['--header="Cookie: "%s"'])
+    params += optional_switch(resource[:cookie], ['--header="Cookie: %s"'])
     params += optional_switch(resource[:proxy_server], ["--#{resource[:proxy_type]}_proxy=#{resource[:proxy_server]}"])
 
     wget(params)

--- a/spec/unit/puppet/provider/archive/wget_spec.rb
+++ b/spec/unit/puppet/provider/archive/wget_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe wget_provider do
       end
 
       it 'calls wget with default options and header containing cookie' do
-        expect(provider).to receive(:wget).with(default_options << '--header="Cookie: "foo"')
+        expect(provider).to receive(:wget).with(default_options << '--header="Cookie: foo"')
         provider.download(name)
       end
     end


### PR DESCRIPTION
Fix surplus double quotes in Cookie header during wget params formatting.