### PR TITLE
GH-146 set aws_cli_install default to false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,7 @@ class archive (
   $seven_zip_provider = $archive::params::seven_zip_provider,
   $seven_zip_source   = undef,
   $gem_provider       = undef,
-  $aws_cli_install    = $archive::params::aws_cli_install,
+  $aws_cli_install    = false,
 ) inherits archive::params {
 
   if $::osfamily == 'Windows' and !($seven_zip_provider in ['', undef]) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,11 +22,4 @@ class archive::params {
       $seven_zip_provider = undef
     }
   }
-
-  # Amazon Linux already have aws cli installed:
-  if getvar('::ec2_metadata') and $::operatingsystem != 'Amazon' {
-    $aws_cli_install = true
-  } else {
-    $aws_cli_install = false
-  }
 }

--- a/spec/classes/archive_spec.rb
+++ b/spec/classes/archive_spec.rb
@@ -10,6 +10,9 @@ describe 'archive' do
 
     context 'default' do
       it { should_not contain_package('7zip') }
+      it { should_not contain_file('/opt/awscli-bundle') }
+      it { should_not contain_archive('awscli-bundle.zip') }
+      it { should_not contain_exec('install_aws_cli') }
     end
 
     context 'with aws_cli' do


### PR DESCRIPTION
Since at this point we can't determine difference between openstack and
AWS ec_* facts, we will default the install to false and let the end
user make the appropriate choice.