### PR TITLE
Problem with URL generated by function assemble_nexus_url when version contains a plus sign ("+")

### DIFF
--- a/lib/puppet/parser/functions/assemble_nexus_url.rb
+++ b/lib/puppet/parser/functions/assemble_nexus_url.rb
@@ -1,10 +1,12 @@
+require 'cgi'
+
 module Puppet::Parser::Functions
   newfunction(:assemble_nexus_url, :type => :rvalue) do |args|
     service_relative_url = 'service/local/artifact/maven/content'
 
     nexus_url = args[0]
     params = args[1]
-    query_string = params.to_a.map { |x| "#{x[0]}=#{x[1]}" }.join('&')
+    query_string = params.to_a.map { |x| "#{x[0]}=#{CGI.escape(x[1])}" }.join('&')
 
     "#{nexus_url}/#{service_relative_url}?#{query_string}"
   end

--- a/spec/unit/puppet/parser/functions/assemble_nexus_url_spec.rb
+++ b/spec/unit/puppet/parser/functions/assemble_nexus_url_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe :assemble_nexus_url do
+
+  before :all do
+    Puppet::Parser::Functions.autoloader.loadall
+  end
+
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  nexus_url = 'http://nexus.local'
+
+  it 'should build url correctly' do
+    expected_url = 'http://nexus.local/service/local/artifact/maven/content?g=com.test&a=test&v=1.0.0&r=binary-staging&p=ear'
+
+    parameters = {
+      'g' => 'com.test',
+      'a' => 'test',
+      'v' => '1.0.0',
+      'r' => 'binary-staging',
+      'p' => 'ear',
+    }
+
+    expect(scope.function_assemble_nexus_url([nexus_url, parameters])).to eq expected_url
+  end
+
+  it 'should build url with version containing "+" sign correctly' do
+    expected_url = 'http://nexus.local/service/local/artifact/maven/content?g=com.test&a=test&v=1.0.0%2B11&r=binary-staging&p=ear'
+
+    parameters = {
+      'g' => 'com.test',
+      'a' => 'test',
+      'v' => '1.0.0+11',
+      'r' => 'binary-staging',
+      'p' => 'ear',
+    }
+
+    expect(scope.function_assemble_nexus_url([nexus_url, parameters])).to eq expected_url
+  end
+
+end

--- a/spec/unit/puppet/parser/functions/assemble_nexus_url_spec.rb
+++ b/spec/unit/puppet/parser/functions/assemble_nexus_url_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe :assemble_nexus_url do
-
   before :all do
     Puppet::Parser::Functions.autoloader.loadall
   end
@@ -37,5 +36,4 @@ describe :assemble_nexus_url do
 
     expect(scope.function_assemble_nexus_url([nexus_url, parameters])).to eq expected_url
   end
-
 end


### PR DESCRIPTION
I had a problem when I tried to download an artifact from local nexus which version contains a "+" symbol. Nexus recognizes it as a "space", and I couldn't download the artifact. So I added the CGI.escape method wrapping the parameter values to build a valid url to nexus:

```
query_string = params.to_a.map { |x| "#{x[0]}=#{CGI.escape(x[1])}" }.join('&')
```

As only in archive::nexus the module is responsible to build the URL, I think this is the right way to correct it.