### PR TITLE
Ruby 1.8.7 does not have options hash

### DIFF
--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -41,7 +41,9 @@ module PuppetX
       end
 
       def follow_redirect(uri, option = { :limit => FOLLOW_LIMIT }, &block)
-        Net::HTTP.start(uri.host, uri.port, :use_ssl => (uri.scheme == 'https')) do |http|
+        req = Net::HTTP.new(uri.host, uri.port)
+        req.use_ssl = (uri.scheme == 'https')
+        req.start do |http|
           http.request(generate_request(uri)) do |response|
             case response
             when Net::HTTPSuccess


### PR DESCRIPTION
Ruby 1.8.7 Net::HTTP.start does not accept a hash of options.
This change allows it to work in both 1.8.7 and newer rubies.