### PR TITLE
make our type camptocamp/archive compatible

### DIFF
--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -139,9 +139,11 @@ Puppet::Type.newtype(:archive) do
 
   newparam(:checksum) do
     desc 'archive file checksum (match checksum_type).'
-    newvalues(%r{\b[0-9a-f]{5,128}\b}, :true, :false)
+    newvalues(%r{\b[0-9a-f]{5,128}\b}, :true, :false, :undef, nil, '')
     munge do |val|
-      if val == :true || val == :false
+      if val.nil? || val.empty? || val == :undef
+        :false
+      elsif val == :true || val == :false
         resource[:checksum_verify] = val
       else
         val

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -76,6 +76,17 @@ Puppet::Type.newtype(:archive) do
       end
     end
   end
+  newparam(:target) do
+    desc 'target folder path to extract archive. (this parameter is for camptocamp/archive compatibility)'
+    validate do |value|
+      unless Puppet::Util.absolute_path? value
+        raise ArgumentError, "archive extract_path must be absolute: #{value}"
+      end
+    end
+    munge do |val|
+      resource[:extract_path] = val
+    end
+  end
 
   newparam(:extract_command) do
     desc "custom extraction command ('tar xvf example.tar.gz'), also support sprintf format ('tar xvf %s') which will be processed with the filename: sprintf('tar xvf %s', filename)"
@@ -109,23 +120,71 @@ Puppet::Type.newtype(:archive) do
     end
   end
 
+  newparam(:url) do
+    desc 'archive file source, supports http|https|ftp|file uri.
+    (for camptocamp/archive compatibility)'
+    validate do |value|
+      unless value =~ URI.regexp(%w(http https file ftp))
+        raise ArgumentError, "invalid source url: #{value}"
+      end
+    end
+    munge do |val|
+      resource[:source] = val
+    end
+  end
+
   newparam(:cookie) do
     desc 'archive file download cookie.'
   end
 
   newparam(:checksum) do
     desc 'archive file checksum (match checksum_type).'
+    newvalues(%r{\b[0-9a-f]{5,128}\b}, :true, :false)
+    munge do |val|
+      if val == :true || val == :false
+        resource[:checksum_verify] = val
+      else
+        val
+      end
+    end
+  end
+  newparam(:digest_string) do
+    desc 'archive file checksum (match checksum_type)
+    (this parameter is for camptocamp/archive compatibility).'
     newvalues(%r{\b[0-9a-f]{5,128}\b})
+    munge do |val|
+      if !val.nil? && !val.empty?
+        resource[:checksum] = val
+      else
+        val
+      end
+    end
   end
 
   newparam(:checksum_url) do
-    desc 'archive file checksum source (instead of specify checksum)'
+    desc 'archive file checksum source (instead of specifying checksum)'
+  end
+  newparam(:digest_url) do
+    desc 'archive file checksum source (instead of specifying checksum)
+    (this parameter is for camptocamp/archive compatibility)'
+    munge do |val|
+      resource[:checksum_url] = val
+    end
   end
 
   newparam(:checksum_type) do
     desc 'archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512).'
     newvalues(:none, :md5, :sha1, :sha2, :sha256, :sha384, :sha512)
     defaultto(:none)
+  end
+  newparam(:digest_type) do
+    desc 'archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512)
+    (this parameter is camptocamp/archive compatibility).'
+    newvalues(:none, :md5, :sha1, :sha2, :sha256, :sha384, :sha512)
+    defaultto(:none)
+    munge do |val|
+      resource[:checksum_type] = val
+    end
   end
 
   newparam(:checksum_verify) do
@@ -175,6 +234,12 @@ Puppet::Type.newtype(:archive) do
   validate do
     filepath = Pathname.new(self[:path])
     self[:filename] = filepath.basename.to_s
+    if !self[:source].nil? && !self[:url].nil? && self[:source] != self[:url]
+      raise ArgumentError, "invalid parameter: url (#{self[:url]}) and source (#{self[:source]}) are mutually exclusive."
+    end
+    if !self[:checksum_url].nil? && !self[:digest_url].nil? && self[:checksum_url] != self[:digest_url]
+      raise ArgumentError, "invalid parameter: checksum_url (#{self[:checksum_url]}) and digest_url (#{self[:digest_url]}) are mutually exclusive."
+    end
     if self[:proxy_server]
       self[:proxy_type] ||= URI(self[:proxy_server]).scheme.to_sym
     else

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -1,0 +1,64 @@
+# == Definition: archive::download
+#
+# Archive downloader with integrity verification.
+#
+# Parameters:
+#
+# - *$url:
+# - *$digest_url:
+# - *$digest_string: Default value undef
+# - *$digest_type: Default value "md5".
+# - *$timeout: Default value 120. (ignored)
+# - *$src_target: Default value "/usr/src".
+# - *$allow_insecure: Default value false.
+# - *$follow_redirects: Default value false.
+# - *$verbose: Default value true.
+# - *$proxy_server: Default value undef.
+# - *$user: The user used to download the archive
+#
+# Example usage:
+#
+#  archive::download {"apache-tomcat-6.0.26.tar.gz":
+#    ensure => present,
+#    url    => "http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.26/bin/apache-tomcat-6.0.26.tar.gz",
+#  }
+#
+#  archive::download {"apache-tomcat-6.0.26.tar.gz":
+#    ensure        => present,
+#    digest_string => "f9eafa9bfd620324d1270ae8f09a8c89",
+#    url           => "http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.26/bin/apache-tomcat-6.0.26.tar.gz",
+#  }
+#
+define archive::download (
+  $url,
+  $ensure           = present,
+  $checksum         = true,
+  $digest_url       = undef,
+  $digest_string    = undef,
+  $digest_type      = 'md5',   # bad default!
+  $timeout          = 120,     # ignored
+  $src_target       = '/usr/src',
+  $allow_insecure   = false,   # ignored
+  $follow_redirects = false,   # ignored (default)
+  $verbose          = true,    # ignored
+  $path             = $::path, # ignored
+  $proxy_server     = undef,
+  $user             = undef,
+) {
+
+  $target = is_absolute_path($title) ? {
+    false   => "${src_target}/${title}",
+    default => $title,
+  }
+
+  archive { $target:
+    ensure          => $ensure,
+    source          => $url,
+    checksum_verify => $checksum,
+    checksum        => $digest_string,
+    checksum_type   => $digest_type,
+    checksum_url    => $digest_url,
+    proxy_server    => $proxy_server,
+    user            => $user,
+  }
+}


### PR DESCRIPTION
our type now accepts the same parameters as camptocamp/archive and processes them correctly.