### PR TITLE
GH-175 Fix provider checksum content fetch method.

### DIFF
--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -2,21 +2,42 @@ Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
   commands curl: 'curl'
   defaultfor feature: :posix
 
-  def download(filepath)
-    params = [
-      resource[:source],
-      '-o',
-      filepath,
-      '-fsSL',
-      '--max-redirs',
-      5
-    ]
-
+  def curl_params(params)
     account = [resource[:username], resource[:password]].compact.join(':') if resource[:username]
     params += optional_switch(account, ['--user', '%s'])
     params += optional_switch(resource[:cookie], ['--cookie', '%s'])
     params += optional_switch(resource[:proxy_server], ['--proxy', '%s'])
 
+    params
+  end
+
+  def download(filepath)
+    params = curl_params(
+      [
+        resource[:source],
+        '-o',
+        filepath,
+        '-fsSL',
+        '--max-redirs',
+        5
+      ]
+    )
+
     curl(params)
+  end
+
+  def remote_checksum
+    @remote_checksum ||= begin
+      params = curl_params(
+        [
+          resource[:checksum_url],
+          '-fsSL',
+          '--max-redirs',
+          5
+        ]
+      )
+
+      curl(params)[%r{\b[\da-f]{32,128}\b}i]
+    end
   end
 end

--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -65,7 +65,7 @@ Puppet::Type.type(:archive).provide(:ruby) do
   end
 
   def checksum
-    resource[:checksum] || remote_checksum
+    resource[:checksum] || (remote_checksum if resource[:checksum_url])
   end
 
   def remote_checksum
@@ -75,7 +75,7 @@ Puppet::Type.type(:archive).provide(:ruby) do
         username: resource[:username],
         password: resource[:password],
         cookie: resource[:cookie]
-      )[%r{\b[\da-f]{32,128}\b}i] if resource[:checksum_url]
+      )[%r{\b[\da-f]{32,128}\b}i]
     end
   end
 

--- a/lib/puppet/provider/archive/wget.rb
+++ b/lib/puppet/provider/archive/wget.rb
@@ -1,22 +1,43 @@
 Puppet::Type.type(:archive).provide(:wget, parent: :ruby) do
   commands wget: 'wget'
 
-  def download(filepath)
-    params = [
-      resource[:source],
-      '-O',
-      filepath,
-      '--max-redirect=5'
-    ]
-
+  def wget_params(params)
     params += optional_switch(resource[:username], ['--user=%s'])
     params += optional_switch(resource[:password], ['--password=%s'])
     params += optional_switch(resource[:cookie], ['--header="Cookie: %s"'])
     params += optional_switch(resource[:proxy_server], ["--#{resource[:proxy_type]}_proxy=#{resource[:proxy_server]}"])
 
+    params
+  end
+
+  def download(filepath)
+    params = wget_params(
+      [
+        Shellwords.shellescape(resource[:source]),
+        '-O',
+        filepath,
+        '--max-redirect=5'
+      ]
+    )
+
     # NOTE:
     # Do NOT use wget(params) until https://tickets.puppetlabs.com/browse/PUP-6066 is resolved.
     command = "wget #{params.join(' ')}"
     Puppet::Util::Execution.execute(command)
+  end
+
+  def remote_checksum
+    @remote_checksum ||= begin
+      params = wget_params(
+        [
+          '-qO-',
+          Shellwords.shellescape(resource[:checksum_url]),
+          '--max-redirect=5'
+        ]
+      )
+
+      command = "wget #{params.join(' ')}"
+      Puppet::Util::Execution.execute(command)[%r{\b[\da-f]{32,128}\b}i]
+    end
   end
 end

--- a/spec/support/shared_behaviour.rb
+++ b/spec/support/shared_behaviour.rb
@@ -15,39 +15,6 @@ RSpec.shared_examples 'an archive provider' do |provider_class|
       File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'files', 'test.zip'))
     end
 
-    describe '#remote_checksum' do
-      subject { provider.remote_checksum }
-      let(:url) { nil }
-      let(:remote_hash) { nil }
-      before(:each) do
-        resource[:checksum_url] = url if url
-        allow(PuppetX::Bodeco::Util).to receive(:content) .\
-          with(url, any_args).and_return(remote_hash)
-      end
-      context 'unset' do
-        it { is_expected.to be_nil }
-      end
-      context 'with a url' do
-        let(:url) { 'http://example.com/checksum' }
-        context 'responds with hash' do
-          let(:remote_hash) { 'a0c38e1aeb175201b0dacd65e2f37e187657050a' }
-          it { is_expected.to eq('a0c38e1aeb175201b0dacd65e2f37e187657050a') }
-        end
-        context 'responds with hash and newline' do
-          let(:remote_hash) { "a0c38e1aeb175201b0dacd65e2f37e187657050a\n" }
-          it { is_expected.to eq('a0c38e1aeb175201b0dacd65e2f37e187657050a') }
-        end
-        context 'responds with `sha1sum README.md` output' do
-          let(:remote_hash) { "a0c38e1aeb175201b0dacd65e2f37e187657050a  README.md\n" }
-          it { is_expected.to eq('a0c38e1aeb175201b0dacd65e2f37e187657050a') }
-        end
-        context 'responds with `openssl dgst -hex -sha256 README.md` output' do
-          let(:remote_hash) { "SHA256(README.md)= 8fa3f0ff1f2557657e460f0f78232679380a9bcdb8670e3dcb33472123b22428\n" }
-          it { is_expected.to eq('8fa3f0ff1f2557657e460f0f78232679380a9bcdb8670e3dcb33472123b22428') }
-        end
-      end
-    end
-
     it '#checksum?' do
       Dir.mktmpdir do |dir|
         resource[:path] = File.join(dir, resource[:filename])

--- a/spec/unit/puppet/provider/archive/curl_spec.rb
+++ b/spec/unit/puppet/provider/archive/curl_spec.rb
@@ -97,5 +97,40 @@ RSpec.describe curl_provider do
         provider.download(name)
       end
     end
+
+    describe '#checksum' do
+      subject { provider.checksum }
+      let(:url) { nil }
+      let(:resource_properties) do
+        {
+          name: name,
+          source: 'http://home.lan/example.zip'
+        }
+      end
+
+      before(:each) do
+        resource[:checksum_url] = url if url
+      end
+
+      context 'with a url' do
+        let(:curl_params) do
+          [
+            'http://example.com/checksum',
+            '-fsSL',
+            '--max-redirs',
+            5
+          ]
+        end
+
+        let(:url) { 'http://example.com/checksum' }
+        context 'responds with hash' do
+          let(:remote_hash) { 'a0c38e1aeb175201b0dacd65e2f37e187657050a' }
+          it do
+            expect(provider).to receive(:curl).with(curl_params).and_return("a0c38e1aeb175201b0dacd65e2f37e187657050a README.md\n")
+            expect(provider.checksum).to eq('a0c38e1aeb175201b0dacd65e2f37e187657050a')
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/unit/puppet/provider/archive/ruby_spec.rb
+++ b/spec/unit/puppet/provider/archive/ruby_spec.rb
@@ -4,22 +4,21 @@ RSpec.describe ruby_provider do
   it_behaves_like 'an archive provider', ruby_provider
 
   describe 'ruby provider' do
-    let(:name)      { '/tmp/example.zip' }
-    let(:resource)  { Puppet::Type::Archive.new(resource_properties) }
-    let(:provider)  { ruby_provider.new(resource) }
+    let(:name) { '/tmp/example.zip' }
+    let(:resource_properties) do
+      {
+        name: name,
+        source: 's3://home.lan/example.zip'
+      }
+    end
+    let(:resource) { Puppet::Type::Archive.new(resource_properties) }
+    let(:provider) { ruby_provider.new(resource) }
 
     let(:s3_download_options) do
       ['s3', 'cp', 's3://home.lan/example.zip', String]
     end
 
     context 'default resource property' do
-      let(:resource_properties) do
-        {
-          name: name,
-          source: 's3://home.lan/example.zip'
-        }
-      end
-
       it '#s3_download' do
         expect(provider).to receive(:aws).with(s3_download_options)
         provider.s3_download(name)
@@ -27,6 +26,41 @@ RSpec.describe ruby_provider do
 
       it '#extract nothing' do
         expect(provider.extract).to be_nil
+      end
+    end
+
+    describe '#checksum' do
+      subject { provider.checksum }
+      let(:url) { nil }
+      let(:remote_hash) { nil }
+      before(:each) do
+        resource[:checksum_url] = url if url
+        allow(PuppetX::Bodeco::Util).to receive(:content) .\
+          with(url, any_args).and_return(remote_hash)
+      end
+
+      context 'unset' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'with a url' do
+        let(:url) { 'http://example.com/checksum' }
+        context 'responds with hash' do
+          let(:remote_hash) { 'a0c38e1aeb175201b0dacd65e2f37e187657050a' }
+          it { is_expected.to eq('a0c38e1aeb175201b0dacd65e2f37e187657050a') }
+        end
+        context 'responds with hash and newline' do
+          let(:remote_hash) { "a0c38e1aeb175201b0dacd65e2f37e187657050a\n" }
+          it { is_expected.to eq('a0c38e1aeb175201b0dacd65e2f37e187657050a') }
+        end
+        context 'responds with `sha1sum README.md` output' do
+          let(:remote_hash) { "a0c38e1aeb175201b0dacd65e2f37e187657050a  README.md\n" }
+          it { is_expected.to eq('a0c38e1aeb175201b0dacd65e2f37e187657050a') }
+        end
+        context 'responds with `openssl dgst -hex -sha256 README.md` output' do
+          let(:remote_hash) { "SHA256(README.md)= 8fa3f0ff1f2557657e460f0f78232679380a9bcdb8670e3dcb33472123b22428\n" }
+          it { is_expected.to eq('8fa3f0ff1f2557657e460f0f78232679380a9bcdb8670e3dcb33472123b22428') }
+        end
       end
     end
   end

--- a/spec/unit/puppet/provider/archive/wget_spec.rb
+++ b/spec/unit/puppet/provider/archive/wget_spec.rb
@@ -96,5 +96,40 @@ RSpec.describe wget_provider do
         provider.download(name)
       end
     end
+
+    describe '#checksum' do
+      subject { provider.checksum }
+      let(:url) { nil }
+      let(:resource_properties) do
+        {
+          name: name,
+          source: 'http://home.lan/example.zip'
+        }
+      end
+
+      before(:each) do
+        resource[:checksum_url] = url if url
+      end
+
+      context 'with a url' do
+        let(:wget_params) do
+          [
+            'wget',
+            '-qO-',
+            'http://example.com/checksum',
+            '--max-redirect=5'
+          ]
+        end
+
+        let(:url) { 'http://example.com/checksum' }
+        context 'responds with hash' do
+          let(:remote_hash) { 'a0c38e1aeb175201b0dacd65e2f37e187657050a' }
+          it do
+            expect(Puppet::Util::Execution).to receive(:execute).with(wget_params.join(' ')).and_return("a0c38e1aeb175201b0dacd65e2f37e187657050a README.md\n")
+            expect(provider.checksum).to eq('a0c38e1aeb175201b0dacd65e2f37e187657050a')
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
If a user switch providers, we should use the same provider to obtain
checksum content.