### PR TITLE
Add `allow_insecure` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ NOTE: Alternative s3 provider support can be implemented by overriding the [s3_d
 * `source`: archive file source, supports http|https|ftp|file|s3 uri.
 * `username`: username to download source file.
 * `password`: password to download source file.
+* `allow_insecure`: Ignore HTTPS certificate errors (true|false). Supported on `curl` and `wget` providers. (default: false)
 * `cookie`: archive file download cookie.
 * `checksum_type`: archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512). (default: none)
 * `checksum`: archive file checksum (match checksum_type)

--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -1,12 +1,14 @@
 Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
   commands curl: 'curl'
   defaultfor feature: :posix
+  has_feature :insecure_https
 
   def curl_params(params)
     account = [resource[:username], resource[:password]].compact.join(':') if resource[:username]
     params += optional_switch(account, ['--user', '%s'])
     params += optional_switch(resource[:cookie], ['--cookie', '%s'])
     params += optional_switch(resource[:proxy_server], ['--proxy', '%s'])
+    params += ['--insecure'] if resource[:allow_insecure]
 
     params
   end

--- a/lib/puppet/provider/archive/wget.rb
+++ b/lib/puppet/provider/archive/wget.rb
@@ -1,11 +1,13 @@
 Puppet::Type.type(:archive).provide(:wget, parent: :ruby) do
   commands wget: 'wget'
+  has_feature :insecure_https
 
   def wget_params(params)
     params += optional_switch(resource[:username], ['--user=%s'])
     params += optional_switch(resource[:password], ['--password=%s'])
     params += optional_switch(resource[:cookie], ['--header="Cookie: %s"'])
     params += optional_switch(resource[:proxy_server], ["--#{resource[:proxy_type]}_proxy=#{resource[:proxy_server]}"])
+    params += ['--no-check-certificate'] if resource[:allow_insecure]
 
     params
   end

--- a/spec/unit/puppet/provider/archive/curl_spec.rb
+++ b/spec/unit/puppet/provider/archive/curl_spec.rb
@@ -68,6 +68,21 @@ RSpec.describe curl_provider do
       end
     end
 
+    context 'allow_insecure true' do
+      let(:resource_properties) do
+        {
+          name: name,
+          source: 'http://home.lan/example.zip',
+          allow_insecure: true
+        }
+      end
+
+      it 'calls curl with default options and --insecure' do
+        expect(provider).to receive(:curl).with(default_options << '--insecure')
+        provider.download(name)
+      end
+    end
+
     context 'cookie specified' do
       let(:resource_properties) do
         {

--- a/spec/unit/puppet/provider/archive/wget_spec.rb
+++ b/spec/unit/puppet/provider/archive/wget_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe wget_provider do
       end
     end
 
+    context 'allow_insecure true' do
+      let(:resource_properties) do
+        {
+          name: name,
+          source: 'http://home.lan/example.zip',
+          allow_insecure: true
+        }
+      end
+
+      it 'calls wget with default options and --no-check-certificate' do
+        expect(execution).to receive(:execute).with([default_options, '--no-check-certificate'].join(' '))
+        provider.download(name)
+      end
+    end
     describe '#checksum' do
       subject { provider.checksum }
       let(:url) { nil }

--- a/spec/unit/puppet/type/archive_spec.rb
+++ b/spec/unit/puppet/type/archive_spec.rb
@@ -18,6 +18,7 @@ describe Puppet::Type.type(:archive) do
     expect(resource[:checksum_type]).to eq :none
     expect(resource[:checksum_verify]).to eq :true
     expect(resource[:extract_flags]).to eq :undef
+    expect(resource[:allow_insecure]).to eq false
   end
 
   it 'verify resource[:path] is absolute filepath' do
@@ -85,6 +86,18 @@ describe Puppet::Type.type(:archive) do
     expect do
       resource[:checksum_type] = :crc32
     end.to raise_error(Puppet::Error, %r{Invalid value})
+  end
+
+  it 'verify resource[:allow_insecure] is valid' do
+    expect do
+      [:true, :false, :yes, :no].each do |type|
+        resource[:allow_insecure] = type
+      end
+    end.not_to raise_error
+
+    expect do
+      resource[:allow_insecure] = :foobar
+    end.to raise_error(Puppet::Error, %r{expected a boolean value})
   end
 
   describe 'autorequire parent path' do


### PR DESCRIPTION
Implemented and tested with `curl` and `wget` providers.
It'll raise an error if you try to use the parameter with the `ruby`
provider.