### PR TITLE
Update metadata.json dependencies and requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,8 +33,7 @@
         "4",
         "5",
         "6",
-        "7",
-        "8"
+        "7"
       ]
     },
     {
@@ -91,7 +90,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.4.0 < 5.0.0"
     }
   ],
   "name": "puppet-archive",
@@ -106,7 +105,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.2.0 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
`Puppet::Parameter::Boolean` isn't available before `puppet 3.3`.
`delete_undef_values()` function was introduced in `stdlib 4.2.0`.