### PR TITLE
Syntax fix for ruby 1.8

### DIFF
--- a/lib/facter/archive_windir.rb
+++ b/lib/facter/archive_windir.rb
@@ -1,5 +1,5 @@
 Facter.add(:archive_windir) do
-  confine osfamily: :windows
+  confine :osfamily => :windows
   setcode do
     program_data = `echo %SYSTEMDRIVE%\\ProgramData`.chomp
     if File.directory? program_data


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

I know we do not support ruby 1.8 anymore, but this seems like a very small fix; a similar fix was made for puppet-staging (see second change in link below):

https://github.com/voxpupuli/puppet-staging/commit/6729b2a313e647af881d26f0e11b4f7fb7432b59

I've patched this locally, as I still have a great many CentOS 6 machines to support.  Would be nice to get it into upstream for next release, if no objections.