### PR TITLE
Fix GH-204 resolve camptocamp archive regression

### DIFF
--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -28,17 +28,15 @@ Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
   end
 
   def remote_checksum
-    @remote_checksum ||= begin
-      params = curl_params(
-        [
-          resource[:checksum_url],
-          '-fsSL',
-          '--max-redirs',
-          5
-        ]
-      )
+    params = curl_params(
+      [
+        resource[:checksum_url],
+        '-fsSL',
+        '--max-redirs',
+        5
+      ]
+    )
 
-      curl(params)[%r{\b[\da-f]{32,128}\b}i]
-    end
+    curl(params)[%r{\b[\da-f]{32,128}\b}i]
   end
 end

--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -65,21 +65,19 @@ Puppet::Type.type(:archive).provide(:ruby) do
   end
 
   def checksum
-    resource[:checksum] || (remote_checksum if resource[:checksum_url])
+    resource[:checksum] || (resource[:checksum] = remote_checksum if resource[:checksum_url])
   end
 
   def remote_checksum
-    @remote_checksum ||= begin
-      PuppetX::Bodeco::Util.content(
-        resource[:checksum_url],
-        username: resource[:username],
-        password: resource[:password],
-        cookie: resource[:cookie],
-        proxy_server: resource[:proxy_server],
-        proxy_type: resource[:proxy_type],
-        insecure: resource[:allow_insecure]
-      )[%r{\b[\da-f]{32,128}\b}i]
-    end
+    PuppetX::Bodeco::Util.content(
+      resource[:checksum_url],
+      username: resource[:username],
+      password: resource[:password],
+      cookie: resource[:cookie],
+      proxy_server: resource[:proxy_server],
+      proxy_type: resource[:proxy_type],
+      insecure: resource[:allow_insecure]
+    )[%r{\b[\da-f]{32,128}\b}i]
   end
 
   # Private: See if local archive checksum matches.

--- a/lib/puppet/provider/archive/wget.rb
+++ b/lib/puppet/provider/archive/wget.rb
@@ -28,17 +28,15 @@ Puppet::Type.type(:archive).provide(:wget, parent: :ruby) do
   end
 
   def remote_checksum
-    @remote_checksum ||= begin
-      params = wget_params(
-        [
-          '-qO-',
-          Shellwords.shellescape(resource[:checksum_url]),
-          '--max-redirect=5'
-        ]
-      )
+    params = wget_params(
+      [
+        '-qO-',
+        Shellwords.shellescape(resource[:checksum_url]),
+        '--max-redirect=5'
+      ]
+    )
 
-      command = "wget #{params.join(' ')}"
-      Puppet::Util::Execution.execute(command)[%r{\b[\da-f]{32,128}\b}i]
-    end
+    command = "wget #{params.join(' ')}"
+    Puppet::Util::Execution.execute(command)[%r{\b[\da-f]{32,128}\b}i]
   end
 end

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -184,7 +184,6 @@ Puppet::Type.newtype(:archive) do
     desc 'archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512)
     (this parameter is camptocamp/archive compatibility).'
     newvalues(:none, :md5, :sha1, :sha2, :sha256, :sha384, :sha512)
-    defaultto(:none)
     munge do |val|
       resource[:checksum_type] = val
     end

--- a/spec/unit/puppet/type/archive_spec.rb
+++ b/spec/unit/puppet/type/archive_spec.rb
@@ -17,6 +17,7 @@ describe Puppet::Type.type(:archive) do
     expect(resource[:extract]).to eq :false
     expect(resource[:cleanup]).to eq :true
     expect(resource[:checksum_type]).to eq :none
+    expect(resource[:digest_type]).to eq nil
     expect(resource[:checksum_verify]).to eq :true
     expect(resource[:extract_flags]).to eq :undef
     expect(resource[:allow_insecure]).to eq false


### PR DESCRIPTION
The camptocamp archive digest_type default of :none overwrote puppet
archive checksum_type value, so even when we have a valid checksum such
as md5, the digest_type overwrote to :none. This results in files with
invalid checksums not being replaced. This PR addresses this bug.