### PR TITLE
Make fact confinement ruby 1.8 compatible

### DIFF
--- a/lib/facter/archive_windir.rb
+++ b/lib/facter/archive_windir.rb
@@ -1,5 +1,5 @@
 Facter.add(:archive_windir) do
-  confine osfamily: :windows
+  confine :osfamily => :windows # rubocop:disable Style/HashSyntax
   setcode do
     program_data = `echo %SYSTEMDRIVE%\\ProgramData`.chomp
     if File.directory? program_data


### PR DESCRIPTION
This is useful for people who have both older systems (using ruby 1.8)
and newer in the same puppet environment. They want to use
puppet-archive on their newer OSes, but don't want their old systems to
throw errors when trying to run facter code they don't even care about.

The module is still not useable on ruby 1.8 and ruby 1.8 fixes to the
type/providers will not be accepted on the master branch.