### PR TITLE
added temp_dir option to override OS temp dir location

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ NOTE: Alternative s3 provider support can be implemented by overriding the
   (default: false)
 * `extract_path`: target folder path to extract archive.
 * `extract_command`: custom extraction command ('tar xvf example.tar.gz'), also
+* `temp_dir`: specify an alternative temporary directory to use for file downloads, if unset the OS default is used
   support sprintf format ('tar xvf %s') which will be processed with the
   filename: sprintf('tar xvf %s', filename)
 * `extract_flags`: custom extraction options, this replaces the default flags.

--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -117,7 +117,15 @@ Puppet::Type.type(:archive).provide(:ruby) do
   end
 
   def transfer_download(archive_filepath)
-    tempfile = Tempfile.new(tempfile_name)
+    if resource[:temp_dir]
+      unless File.directory?(resource[:temp_dir])
+        raise Puppet::Error, "Temporary directory #{resource[:temp_dir]} doesn't exist"
+      end
+      tempfile = Tempfile.new(tempfile_name, resource[:temp_dir])
+    else
+      tempfile = Tempfile.new(tempfile_name)
+    end
+
     temppath = tempfile.path
     tempfile.close!
 

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -93,6 +93,15 @@ Puppet::Type.newtype(:archive) do
     desc "custom extraction command ('tar xvf example.tar.gz'), also support sprintf format ('tar xvf %s') which will be processed with the filename: sprintf('tar xvf %s', filename)"
   end
 
+  newparam(:temp_dir) do
+    desc 'Specify an alternative temporary directory to use for copying files, if unset then the operating system default will be used.'
+    validate do |value|
+      unless Puppet::Util.absolute_path?(value)
+        raise ArgumentError, "Invalid temp_dir #{value}"
+      end
+    end
+  end
+
   newparam(:extract_flags) do
     desc "custom extraction options, this replaces the default flags. A string such as 'xvf' for a tar file would replace the default xf flag. A hash is useful when custom flags are needed for different platforms. {'tar' => 'xzf', '7z' => 'x -aot'}."
     defaultto(:undef)

--- a/spec/unit/puppet/type/archive_spec.rb
+++ b/spec/unit/puppet/type/archive_spec.rb
@@ -21,12 +21,19 @@ describe Puppet::Type.type(:archive) do
     expect(resource[:checksum_verify]).to eq :true
     expect(resource[:extract_flags]).to eq :undef
     expect(resource[:allow_insecure]).to eq false
+    expect(resource[:temp_dir]).to eq nil
   end
 
   it 'verify resource[:path] is absolute filepath' do
     expect do
       resource[:path] = 'relative/file'
     end.to raise_error(Puppet::Error, %r{archive path must be absolute: })
+  end
+
+  it 'verify resource[:temp_dir] is absolute filetemp_dir' do
+    expect do
+      resource[:temp_dir] = 'relative/file'
+    end.to raise_error(Puppet::Error, %r{Invalid temp_dir})
   end
 
   describe 'on posix', if: Puppet.features.posix? do


### PR DESCRIPTION

The ruby provider, in the `transfer_download` method places the archive file in a location determined by `Tempfile` before checksumming and moving into place.   This can be a problem when dealing with very large files on systems where the OS's temp dir (`/tmp`) isn't large enough.  

I've come across this numerous times now, most recently with this reported issue: https://github.com/crayfishx/puppet-db2/issues/8

This PR adds a new parameter, `temp_dir` allowing you to override the location used for storing temporary files.  If left unset then it will default to the existing behaviour of using the OS's temp dir location.



