### PR TITLE
refactor and document archive ruby provider

### DIFF
--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -120,8 +120,7 @@ module PuppetX
     end
 
     class FILE
-      def initialize(_url, _options)
-      end
+      def initialize(_url, _options) end
 
       def download(uri, file_path)
         FileUtils.copy(uri.path, file_path)


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

use early returns for easier reading of archive's ruby provider.
Since this is the base-provider for wget & curl (and probably future
providers as well), this commit also adds documentation about the
finite-state-machine that we implement (on top of the standard puppet
provider finite-state-machinery).