### PR TITLE
Replace validate_* functions with Puppet 4 data type validations

### DIFF
--- a/manifests/artifactory.pp
+++ b/manifests/artifactory.pp
@@ -11,7 +11,7 @@
 # * url: artifactory download url filepath. NOTE: replaces server, port, url_path parameters.
 # * server: artifactory server name (deprecated).
 # * port: artifactory server port (deprecated).
-# * url_path: artifactory file path http:://{server}:{port}/artifactory/{url_path} (deprecated).
+# * url_path: artifactory file path http://{server}:{port}/artifactory/{url_path} (deprecated).
 # * owner: file owner (see archive params for defaults).
 # * group: file group (see archive params for defaults).
 # * mode: file mode (see archive params for defaults).
@@ -43,20 +43,20 @@
 # }
 #
 define archive::artifactory (
-  $path         = $name,
-  $ensure       = present,
-  $url          = undef,
-  $server       = undef,
-  $port         = undef,
-  $url_path     = undef,
-  $owner        = undef,
-  $group        = undef,
-  $mode         = undef,
-  $archive_path = undef,
-  $extract      = undef,
-  $extract_path = undef,
-  $creates      = undef,
-  $cleanup      = undef,
+  String                                  $path         = $name,
+  Enum['present', 'absent']               $ensure       = present,
+  Optional[Pattern[/^https?:\/\//]]       $url          = undef,
+  Optional[String]                        $server       = undef,
+  Optional[Integer]                       $port         = undef,
+  Optional[String]                        $url_path     = undef,
+  Optional[String]                        $owner        = undef,
+  Optional[String]                        $group        = undef,
+  Optional[String]                        $mode         = undef,
+  Optional[Boolean]                       $extract      = undef,
+  Optional[String]                        $extract_path = undef,
+  Optional[String]                        $creates      = undef,
+  Optional[Boolean]                       $cleanup      = undef,
+  Optional[Stdlib::Compat::Absolute_path] $archive_path = undef,
 ) {
 
   include ::archive::params
@@ -67,7 +67,9 @@ define archive::artifactory (
     $file_path = $path
   }
 
-  validate_absolute_path($file_path)
+  if $file_path !~ Stdlib::Compat::Absolute_path {
+    fail("archive::artifactory[${name}]: \$name or \$archive_path must be an absolute path!") # lint:ignore:trailing_comma
+  }
 
   if $url {
     $file_url = $url

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -30,23 +30,22 @@
 #  }
 #
 define archive::download (
-  $url,
-  $ensure           = present,
-  $checksum         = true,
-  $digest_url       = undef,
-  $digest_string    = undef,
-  $digest_type      = 'md5',   # bad default!
-  $timeout          = 120,     # ignored
-  $src_target       = '/usr/src',
-  $allow_insecure   = false,   # ignored
-  $follow_redirects = false,   # ignored (default)
-  $verbose          = true,    # ignored
-  $path             = $::path, # ignored
-  $proxy_server     = undef,
-  $user             = undef,
+  String                        $url,
+  Enum['present', 'absent']     $ensure  = present,
+  Boolean                       $checksum         = true,
+  Optional[String]              $digest_url       = undef,
+  Optional[String]              $digest_string    = undef,
+  Optional[Enum['none', 'md5', 'sha1', 'sha2','sh256', 'sha384', 'sha512']] $digest_type      = 'md5',   # bad default!
+  Integer                       $timeout          = 120,     # ignored
+  Stdlib::Compat::Absolute_path $src_target       = '/usr/src',
+  Boolean                       $allow_insecure   = false,   # ignored
+  Boolean                       $follow_redirects = false,   # ignored (default)
+  Boolean                       $verbose          = true,    # ignored
+  String                        $path             = $::path, # ignored
+  Optional[String]              $proxy_server     = undef,
+  Optional[String]              $user             = undef,
 ) {
-
-  $target = is_absolute_path($title) ? {
+  $target = ($title =~ Stdlib::Compat::Absolute_path) ? {
     false   => "${src_target}/${title}",
     default => $title,
   }

--- a/manifests/go.pp
+++ b/manifests/go.pp
@@ -1,21 +1,21 @@
 # download from go
 define archive::go (
-  $server,
-  $port,
-  $url_path,
-  $md5_url_path,
-  $username,
-  $password,
-  $path         = $name,
-  $owner        = undef,
-  $group        = undef,
-  $mode         = undef,
-  $archive_path = undef,
-  $ensure       = present,
-  $extract      = undef,
-  $extract_path = undef,
-  $creates      = undef,
-  $cleanup      = undef,
+  String                    $server,
+  Integer                   $port,
+  String                    $url_path,
+  String                    $md5_url_path,
+  String                    $username,
+  String                    $password,
+  Enum['present', 'absent'] $ensure       = present,
+  String                    $path         = $name,
+  Optional[String]          $owner        = undef,
+  Optional[String]          $group        = undef,
+  Optional[String]          $mode         = undef,
+  Optional[Boolean]         $extract      = undef,
+  Optional[String]          $extract_path = undef,
+  Optional[String]          $creates      = undef,
+  Optional[Boolean]         $cleanup      = undef,
+  Optional[Stdlib::Compat::Absolute_path] $archive_path = undef,
 ) {
 
   include ::archive::params
@@ -26,7 +26,9 @@ define archive::go (
     $file_path = $path
   }
 
-  validate_absolute_path($file_path)
+  if $file_path !~ Stdlib::Compat::Absolute_path {
+    fail("archive::go[${name}]: \$name or \$archive_path must be an absolute path!") # lint:ignore:trailing_comma
+  }
 
   $go_url = "http://${server}:${port}"
   $file_url = "${go_url}/${url_path}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,13 +21,13 @@
 # }
 #
 class archive (
-  $seven_zip_name     = $archive::params::seven_zip_name,
-  $seven_zip_provider = $archive::params::seven_zip_provider,
-  $seven_zip_source   = undef,
-  $aws_cli_install    = false,
+  Optional[String] $seven_zip_name     = $archive::params::seven_zip_name,
+  Optional[String] $seven_zip_provider = $archive::params::seven_zip_provider,
+  Optional[String] $seven_zip_source   = undef,
+  Boolean          $aws_cli_install    = false,
 ) inherits archive::params {
 
-  if $::osfamily == 'Windows' and !($seven_zip_provider in ['', undef]) {
+  if $facts['os']['family'] == 'Windows' and !($seven_zip_provider in ['', undef]) {
     package { '7zip':
       ensure   => present,
       name     => $seven_zip_name,
@@ -38,7 +38,7 @@ class archive (
 
   if $aws_cli_install {
     # TODO: Windows support.
-    if $::osfamily != 'Windows' {
+    if $facts['os']['family'] != 'Windows' {
       # Using bundled install option:
       # http://docs.aws.amazon.com/cli/latest/userguide/installing.html#install-bundle-other-os
 

--- a/manifests/nexus.pp
+++ b/manifests/nexus.pp
@@ -19,30 +19,30 @@
 # }
 #
 define archive::nexus (
-  $url,
-  $gav,
-  $repository,
-  $ensure          = present,
-  $checksum_type   = 'md5',
-  $checksum_verify = true,
-  $packaging       = 'jar',
-  $classifier      = undef,
-  $extension       = undef,
-  $username        = undef,
-  $password        = undef,
-  $user            = undef,
-  $owner           = undef,
-  $group           = undef,
-  $mode            = undef,
-  $extract         = undef,
-  $extract_path    = undef,
-  $extract_flags   = undef,
-  $extract_command = undef,
-  $creates         = undef,
-  $cleanup         = undef,
-  $proxy_server    = undef,
-  $proxy_type      = undef,
-  $allow_insecure  = undef,
+  String            $url,
+  String            $gav,
+  String            $repository,
+  Enum['present', 'absent'] $ensure  = present,
+  Enum['none', 'md5', 'sha1', 'sha2','sh256', 'sha384', 'sha512'] $checksum_type   = 'md5',
+  Boolean           $checksum_verify = true,
+  String            $packaging       = 'jar',
+  Optional[String]  $classifier      = undef,
+  Optional[String]  $extension       = undef,
+  Optional[String]  $username        = undef,
+  Optional[String]  $password        = undef,
+  Optional[String]  $user            = undef,
+  Optional[String]  $owner           = undef,
+  Optional[String]  $group           = undef,
+  Optional[String]  $mode            = undef,
+  Optional[Boolean] $extract         = undef,
+  Optional[String]  $extract_path    = undef,
+  Optional[String]  $extract_flags   = undef,
+  Optional[String]  $extract_command = undef,
+  Optional[String]  $creates         = undef,
+  Optional[Boolean] $cleanup         = undef,
+  Optional[String]  $proxy_server    = undef,
+  Optional[String]  $proxy_type      = undef,
+  Optional[Boolean] $allow_insecure  = undef,
 ) {
 
   include ::archive::params
@@ -63,14 +63,10 @@ define archive::nexus (
     'c' => $classifier,
     'e' => $extension,
 
-  }
+  }.filter |$keys, $values| { $values != undef }
 
-  $artifact_url = assemble_nexus_url($url, delete_undef_values($query_params))
+  $artifact_url = assemble_nexus_url($url, $query_params)
   $checksum_url = regsubst($artifact_url, "p=${packaging}", "p=${packaging}.${checksum_type}")
-
-  if $allow_insecure != undef {
-    validate_bool($allow_insecure)
-  }
 
   archive { $name:
     ensure          => $ensure,
@@ -103,5 +99,4 @@ define archive::nexus (
     mode    => $file_mode,
     require => Archive[$name],
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@
 # archive settings such as default user and file mode.
 #
 class archive::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Windows': {
       $path               = $::archive_windir
       $owner              = 'S-1-5-32-544' # Adminstrators

--- a/manifests/staging.pp
+++ b/manifests/staging.pp
@@ -4,10 +4,10 @@
 # backwards compatibility class for staging module.
 #
 class archive::staging (
-  $path  = $archive::params::path,
-  $owner = $archive::params::owner,
-  $group = $archive::params::group,
-  $mode  = $archive::params::mode,
+  String $path  = $archive::params::path,
+  String $owner = $archive::params::owner,
+  String $group = $archive::params::group,
+  String $mode  = $archive::params::mode,
 ) inherits archive::params {
   include '::archive'
 

--- a/metadata.json
+++ b/metadata.json
@@ -90,7 +90,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.8.7 < 5.0.0"
+      "version_requirement": ">=4.6.1 <5.0.0"
     }
   ],
   "name": "puppet-archive",
@@ -105,7 +105,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.13.0 < 5.0.0"
     }
   ]
 }

--- a/spec/classes/archive_spec.rb
+++ b/spec/classes/archive_spec.rb
@@ -4,9 +4,9 @@ describe 'archive' do
   context 'RHEL' do
     let(:facts) do
       {
-        osfamily: 'RedHat',
+        os: { family: 'RedHat' },
         operatingsystem: 'RedHat',
-        puppetversion: '3.7.3'
+        puppetversion: '4.4.0'
       }
     end
 
@@ -35,7 +35,7 @@ describe 'archive' do
   describe 'Windows' do
     let(:default_facts) do
       {
-        osfamily: 'Windows',
+        os: { family: 'Windows' },
         operatingsystem: 'Windows',
         archive_windir: 'C:/staging'
       }
@@ -44,7 +44,7 @@ describe 'archive' do
     context 'default 7zip chcolatey package' do
       let(:facts) do
         {
-          puppetversion: '3.7.3'
+          puppetversion: '4.4.0'
         }.merge(default_facts)
       end
 

--- a/spec/classes/staging_spec.rb
+++ b/spec/classes/staging_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'archive::staging' do
   context 'RHEL Puppet opensource' do
-    let(:facts) { { osfamily: 'RedHat', puppetversion: '3.7.3' } }
+    let(:facts) { { os: { family: 'RedHat' }, puppetversion: '4.4.0' } }
 
     it { is_expected.to contain_class 'archive' }
     it do
@@ -15,7 +15,7 @@ describe 'archive::staging' do
   end
 
   context 'RHEL Puppet opensource with params' do
-    let(:facts) { { osfamily: 'RedHat', puppetversion: '3.7.3' } }
+    let(:facts) { { os: { family: 'RedHat' }, puppetversion: '4.4.0' } }
 
     let(:params) do
       {
@@ -39,7 +39,7 @@ describe 'archive::staging' do
   context 'Windows Puppet Enterprise' do
     let(:facts) do
       {
-        osfamily: 'Windows',
+        os: { family: 'Windows' },
         puppetversion: '3.4.3 (Puppet Enterprise 3.2.3)',
         archive_windir: 'C:/Windows/Temp/staging'
       }

--- a/spec/defines/artifactory_spec.rb
+++ b/spec/defines/artifactory_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'archive::artifactory' do
-  let(:facts) { { osfamily: 'RedHat', puppetversion: '3.7.3' } }
+  let(:facts) { { os: { family: 'RedHat' }, puppetversion: '4.4.0' } }
 
   before do
     MockFunction.new('artifactory_sha1') do |f|

--- a/spec/defines/go_spec.rb
+++ b/spec/defines/go_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'archive::go' do
-  let(:facts) { { osfamily: 'RedHat', puppetversion: '3.7.3' } }
+  let(:facts) { { os: { family: 'RedHat' }, puppetversion: '4.4.0' } }
 
   before do
     MockFunction.new('go_md5') do |f|
@@ -14,7 +14,7 @@ describe 'archive::go' do
     let(:params) do
       {
         server: 'home.lan',
-        port: '8081',
+        port: 8081,
         url_path: 'go/example.zip',
         md5_url_path: 'go/example.zip/checksum',
         username: 'username',
@@ -47,7 +47,7 @@ describe 'archive::go' do
       {
         archive_path: '/opt/app',
         server: 'home.lan',
-        port: '8081',
+        port: 8081,
         url_path: 'go/example.zip',
         md5_url_path: 'go/example.zip/checksum',
         username: 'username',

--- a/spec/defines/nexus_spec.rb
+++ b/spec/defines/nexus_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'archive::nexus' do
-  let(:facts) { { osfamily: 'RedHat', puppetversion: '3.7.3' } }
+  let(:facts) { { os: { family: 'RedHat' }, puppetversion: '4.4.0' } }
 
   context 'nexus archive with defaults' do
     let(:title) { '/tmp/hawtio.war' }
@@ -147,6 +147,6 @@ describe 'archive::nexus' do
         allow_insecure: 'foobar'
       }
     end
-    it { is_expected.to compile.and_raise_error(%r{"foobar" is not a boolean}) }
+    it { is_expected.to compile.and_raise_error(%r{parameter 'allow_insecure' expects a Boolean value, got String}) }
   end
 end


### PR DESCRIPTION
Added Puppet Data types for every parameter.

remove deprecated validate_* and is_* functions from stdlib.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
