### PR TITLE
Fixing a typo on credentials file and add the config too

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,11 @@ class { '::archive':
 
 # See AWS cli guide for credential and configuration settings:
 # http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
-file { '/root/.aws/credential':
+file { '/root/.aws/credentials':
+  ensure => file,
+  ...
+}
+file { '/root/.aws/config':
   ensure => file,
   ...
 }


### PR DESCRIPTION
This PR fixes the name of the credentials file for aws (an "s" is missing) and mention the config file for aws which is generally required as containing the default region.