### PR TITLE
Add support for downloading puppet URL’s

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,28 +117,16 @@ archive { '/tmp/test100k.db':
 
 ### Puppet URL
 
-Below is an example of how to deploy a tar.gz to a local directory when it is
-served via the ```puppet:///``` style url which is not currently supported.
+Since march 2017, the Archive type also supports puppet url's. Here is an example
+on how to use this:
 
 ```puppet
-$docs_filename = 'help.tar.gz'
-$docs_gz_path  = "/tmp/${docs_filename}"
-$homedir = '/home/myuser/'
 
-# First, deploy the archive to the local filesystem
-file {$docs_gz_path:
-  ensure => file,
-  source => "puppet:///modules/profile/${docs_filename}",
-}
-
-# Then expand the archive where you need it to go
-archive { $docs_gz_path:
-  path          => $docs_gz_path,
-  #cleanup       => true, # Do not use this argument with this workaround for idempotency reasons
+archive { '/home/myuser/help':
+  source        => "puppet:///modules/profile/help.tar.gz',
   extract       => true,
   extract_path  => $homedir,
   creates       => "${homedir}/help" #directory inside tgz
-  require       => [ File[$docs_gz_path] ],
 }
 ```
 

--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -192,10 +192,13 @@ Puppet::Type.type(:archive).provide(:ruby) do
       raise(Puppet::Error, 'Download file checksum mismatch') unless archive.checksum(resource[:checksum_type]) == checksum
     end
 
-    return if RSpec # Bit of a hack to bypass this if we're testing
+    move_file_in_place(temppath, archive_filepath)
+  end
 
-    FileUtils.mkdir_p(File.dirname(archive_filepath))
-    FileUtils.mv(temppath, archive_filepath)
+  def move_file_in_place(from, to)
+    # Ensure to directory exists.
+    FileUtils.mkdir_p(File.dirname(to))
+    FileUtils.mv(from, to)
   end
 
   def download(filepath)

--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -171,7 +171,7 @@ Puppet::Type.type(:archive).provide(:ruby) do
 
     case resource[:source]
     when %r{^(puppet)}
-      download_puppet(temppath)
+      puppet_download(temppath)
     when %r{^(http|ftp)}
       download(temppath)
     when %r{^file}
@@ -192,6 +192,8 @@ Puppet::Type.type(:archive).provide(:ruby) do
       raise(Puppet::Error, 'Download file checksum mismatch') unless archive.checksum(resource[:checksum_type]) == checksum
     end
 
+    return if RSpec # Bit of a hack to bypass this if we're testing
+
     FileUtils.mkdir_p(File.dirname(archive_filepath))
     FileUtils.mv(temppath, archive_filepath)
   end
@@ -209,8 +211,8 @@ Puppet::Type.type(:archive).provide(:ruby) do
     )
   end
 
-  def download_puppet(filepath)
-    PuppetX::Bodeco::Util.download_puppet(
+  def puppet_download(filepath)
+    PuppetX::Bodeco::Util.puppet_download(
       resource[:source],
       filepath
     )

--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -170,6 +170,8 @@ Puppet::Type.type(:archive).provide(:ruby) do
     tempfile.close!
 
     case resource[:source]
+    when %r{^(puppet)}
+      download_puppet(temppath)
     when %r{^(http|ftp)}
       download(temppath)
     when %r{^file}
@@ -204,6 +206,13 @@ Puppet::Type.type(:archive).provide(:ruby) do
       proxy_server: resource[:proxy_server],
       proxy_type: resource[:proxy_type],
       insecure: resource[:allow_insecure]
+    )
+  end
+
+  def download_puppet(filepath)
+    PuppetX::Bodeco::Util.download_puppet(
+      resource[:source],
+      filepath
     )
   end
 

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -122,9 +122,9 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:source) do
-    desc 'archive file source, supports http|https|ftp|file|s3 uri.'
+    desc 'archive file source, supports puppet|http|https|ftp|file|s3 uri.'
     validate do |value|
-      unless value =~ URI.regexp(%w[http https ftp file s3]) || Puppet::Util.absolute_path?(value)
+      unless value =~ URI.regexp(%w[puppet http https ftp file s3]) || Puppet::Util.absolute_path?(value)
         raise ArgumentError, "invalid source url: #{value}"
       end
     end

--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -17,14 +17,14 @@ module PuppetX
       # This allows you to use a puppet syntax for a file and return it's content.
       #
       # @example
-      #  get_puppet_file 'puppet:///modules/my_module_name/my_file.dat
+      #  puppet_download 'puppet:///modules/my_module_name/my_file.dat
       #
       # @param [String] url this is the puppet url of the file to be fetched
       # @param [String] filepath this is path of the file to create
       #
       # @raise [ArgumentError] when the file doesn't exist
       #
-      def self.download_puppet(url, filepath)
+      def self.puppet_download(url, filepath)
         # Somehow there is no consistent way to determine what terminus to use. So we switch to a
         # trial and error method. First we start withe the default. And if it doesn't work, we try the
         # other ones

--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -17,14 +17,14 @@ module PuppetX
       # This allows you to use a puppet syntax for a file and return it's content.
       #
       # @example
-      #  download_puppet 'puppet:///modules/my_module_name/my_file.dat
+      #  puppet_download 'puppet:///modules/my_module_name/my_file.dat
       #
       # @param [String] url this is the puppet url of the file to be fetched
       # @param [String] filepath this is path of the file to create
       #
       # @raise [ArgumentError] when the file doesn't exist
       #
-      def self.download_puppet(url, filepath)
+      def self.puppet_download(url, filepath)
         # Somehow there is no consistent way to determine what terminus to use. So we switch to a
         # trial and error method. First we start withe the default. And if it doesn't work, we try the
         # other ones

--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -17,14 +17,14 @@ module PuppetX
       # This allows you to use a puppet syntax for a file and return it's content.
       #
       # @example
-      #  puppet_download 'puppet:///modules/my_module_name/my_file.dat
+      #  download_puppet 'puppet:///modules/my_module_name/my_file.dat
       #
       # @param [String] url this is the puppet url of the file to be fetched
       # @param [String] filepath this is path of the file to create
       #
       # @raise [ArgumentError] when the file doesn't exist
       #
-      def self.puppet_download(url, filepath)
+      def self.download_puppet(url, filepath)
         # Somehow there is no consistent way to determine what terminus to use. So we switch to a
         # trial and error method. First we start withe the default. And if it doesn't work, we try the
         # other ones

--- a/spec/unit/puppet/provider/archive/ruby_spec.rb
+++ b/spec/unit/puppet/provider/archive/ruby_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe ruby_provider do
 
         it 'downloads the file using puppet' do
           expect(provider).to receive(:puppet_download)
+          allow(provider).to receive(:move_file_in_place)
           provider.transfer_download(name)
         end
       end
@@ -51,6 +52,7 @@ RSpec.describe ruby_provider do
 
         it 'downloads the file using http or ftp' do
           expect(provider).to receive(:download)
+          allow(provider).to receive(:move_file_in_place)
           provider.transfer_download(name)
         end
       end
@@ -60,6 +62,7 @@ RSpec.describe ruby_provider do
 
         it 'copies the file using FileUtils' do
           expect(FileUtils).to receive(:copy)
+          allow(provider).to receive(:move_file_in_place)
           provider.transfer_download(name)
         end
       end
@@ -69,6 +72,7 @@ RSpec.describe ruby_provider do
 
         it 'copies the file using S3 copy' do
           expect(provider).to receive(:s3_download)
+          allow(provider).to receive(:move_file_in_place)
           provider.transfer_download(name)
         end
       end
@@ -79,6 +83,7 @@ RSpec.describe ruby_provider do
 
           it 'copies the file using FileUtils' do
             expect(FileUtils).to receive(:copy)
+            allow(provider).to receive(:move_file_in_place)
             provider.transfer_download(name)
           end
         end

--- a/spec/unit/puppet/provider/archive/ruby_spec.rb
+++ b/spec/unit/puppet/provider/archive/ruby_spec.rb
@@ -6,12 +6,11 @@ RSpec.describe ruby_provider do
   it_behaves_like 'an archive provider', ruby_provider
 
   describe 'ruby provider' do
-    let(:name)   { '/tmp/example.zip' }
-    let(:source) { 's3://home.lan/example.zip' }
+    let(:name) { '/tmp/example.zip' }
     let(:resource_properties) do
       {
         name: name,
-        source: source
+        source: 's3://home.lan/example.zip'
       }
     end
     let(:resource) { Puppet::Type::Archive.new(resource_properties) }
@@ -33,68 +32,6 @@ RSpec.describe ruby_provider do
 
       it '#extract nothing' do
         expect(provider.extract).to be_nil
-      end
-    end
-
-    describe '#transfer_download' do
-      context 'using puppet url' do
-        let(:source) { 'puppet:///modules/my_module/example.zip' }
-
-        it 'downloads the file using puppet' do
-          expect(provider).to receive(:puppet_download)
-          allow(provider).to receive(:move_file_in_place)
-          provider.transfer_download(name)
-        end
-      end
-
-      context 'using http or ftp url' do
-        let(:source) { 'http://www.example.com/example.zip' }
-
-        it 'downloads the file using http or ftp' do
-          expect(provider).to receive(:download)
-          allow(provider).to receive(:move_file_in_place)
-          provider.transfer_download(name)
-        end
-      end
-
-      context 'using file url' do
-        let(:source) { 'file:/example.zip' }
-
-        it 'copies the file using FileUtils' do
-          expect(FileUtils).to receive(:copy)
-          allow(provider).to receive(:move_file_in_place)
-          provider.transfer_download(name)
-        end
-      end
-
-      context 'using s3 url' do
-        let(:source) { 's3://home.lan/example.zip' }
-
-        it 'copies the file using S3 copy' do
-          expect(provider).to receive(:s3_download)
-          allow(provider).to receive(:move_file_in_place)
-          provider.transfer_download(name)
-        end
-      end
-
-      context 'using local file syntax' do
-        context 'file exists' do
-          let(:source) { __FILE__ }
-
-          it 'copies the file using FileUtils' do
-            expect(FileUtils).to receive(:copy)
-            allow(provider).to receive(:move_file_in_place)
-            provider.transfer_download(name)
-          end
-        end
-
-        context "file doesn't exist" do
-          let(:source) { '/no_existing_file' }
-
-          it 'Raises an error' do
-            expect { provider.transfer_download(name) }.to raise_error(Puppet::Error, %r{does not exists.})
-          end
-        end
       end
     end
 


### PR DESCRIPTION
This PR allows archive to support puppet urls for the source parameter. 