### PR TITLE
Pass proxy values using the wget -e option

### DIFF
--- a/lib/puppet/provider/archive/wget.rb
+++ b/lib/puppet/provider/archive/wget.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:archive).provide(:wget, parent: :ruby) do
     params += optional_switch(resource[:username], ['--user=%s'])
     params += optional_switch(resource[:password], ['--password=%s'])
     params += optional_switch(resource[:cookie], ['--header="Cookie: %s"'])
-    params += optional_switch(resource[:proxy_server], ["--#{resource[:proxy_type]}_proxy=#{resource[:proxy_server]}"])
+    params += optional_switch(resource[:proxy_server], ['-e use_proxy=yes', "-e #{resource[:proxy_type]}_proxy=#{resource[:proxy_server]}"])
     params += ['--no-check-certificate'] if resource[:allow_insecure]
 
     params

--- a/spec/unit/puppet/provider/archive/wget_spec.rb
+++ b/spec/unit/puppet/provider/archive/wget_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe wget_provider do
 
       it 'calls wget with default options and header containing cookie' do
         provider.download(name)
-        expect(execution).to have_received(:execute).with([default_options, '--https_proxy=https://home.lan:8080'].join(' '))
+        expect(execution).to have_received(:execute).with([default_options, '-e use_proxy=yes', '-e https_proxy=https://home.lan:8080'].join(' '))
       end
     end
 


### PR DESCRIPTION
The provider was passing the wget command proxy command line options directly,
but these options do not currently exist. This change passes the proxy
values using the '-e,--execute <command>' option, which executes the given
command as if it were included in a .wgetrc file.