### PR TITLE
Added support for specifying the region where your S3 bucket lives

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,17 @@ archive { '/tmp/gravatar.png':
 NOTE: Alternative s3 provider support can be implemented by overriding the
 [s3_download method](lib/puppet/provider/archive/ruby.rb):
 
+If you need to specify custom options to the aws CLI command (eg. the region in
+which your S3 Bucket lives) use the awscli_arguments parameter, which is an
+array of all the options you want, including the needed parameters:
+```puppet
+archive { '/tmp/gravatar.png':
+  ensure           => present,
+  source           => 's3://bodecoio/gravatar.png',
+  awscli_arguments => ['--region', 'eu-central-1']
+}
+```
+
 ### Migrating from puppet-staging
 
 It is recommended to use puppet-archive instead of puppet-staging.

--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -176,7 +176,7 @@ Puppet::Type.type(:archive).provide(:ruby) do
       uri = URI(resource[:source])
       FileUtils.copy(Puppet::Util.uri_to_path(uri), temppath)
     when %r{^s3}
-      s3_download(temppath)
+      s3_download(temppath, resource[:awscli_arguments])
     when nil
       raise(Puppet::Error, 'Unable to fetch archive, the source parameter is nil.')
     else
@@ -207,13 +207,18 @@ Puppet::Type.type(:archive).provide(:ruby) do
     )
   end
 
-  def s3_download(path)
+  def s3_download(path, awscli_arguments = :false)
     params = [
       's3',
       'cp',
       resource[:source],
       path
     ]
+    if awscli_arguments != :false
+      awscli_arguments.each do |argument|
+        params.push(argument)
+      end
+    end
 
     aws(params)
   end

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -234,6 +234,11 @@ Puppet::Type.newtype(:archive) do
     defaultto :false
   end
 
+  newparam(:awscli_arguments) do
+    desc 'Add specific arguments to the aws cli tool'
+    defaultto(:false)
+  end
+
   autorequire(:file) do
     [
       Pathname.new(self[:path]).parent.to_s,

--- a/spec/unit/puppet/provider/archive/ruby_spec.rb
+++ b/spec/unit/puppet/provider/archive/ruby_spec.rb
@@ -69,5 +69,30 @@ RSpec.describe ruby_provider do
         end
       end
     end
+
+    describe '#s3_with_bucket' do
+      let(:resource_properties) do
+        {
+          name: name,
+          source: 's3://home.lan/example.zip',
+          awscli_arguments: ['--region', 'eu-central-1']
+        }
+      end
+
+      let(:s3_download_options_with_bucket) do
+        ['s3', 'cp', 's3://home.lan/example.zip', String, '--region', 'eu-central-1']
+      end
+
+      before do
+        allow(provider).to receive(:aws)
+      end
+
+      context 'default resource property' do
+        it '#s3_download' do
+          provider.s3_download(name, ['--region', 'eu-central-1'])
+          expect(provider).to have_received(:aws).with(s3_download_options_with_bucket)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Added a new parameter to the Archive module: s3_region. With this optional parameter you can specify in which region your S3 bucket lives. When you don't specify the s3_region, the old behavior is maintained.

When you do specify the s3_region parameter, the --region $s3_region is added to the aws command that this module runs in the end.

If I didn't specify this for my S3 bucket, I got an HTTP 400 response, which prevented me from downloading the file. Now I can download it.

If you have any questions, remarks or improvements, please let me know.