### PR TITLE
Support Nexus 3 urls for artifact downloads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ add tests if you're adding new functionality. If you've not used
 [rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
 about how best to test your new feature.
 
-To run your all the unit tests
+To run all the unit tests
 
     bundle exec rake spec SPEC_OPTS='--format documentation'
 
@@ -92,6 +92,6 @@ run the integration tests against Centos 6.5 with.
 If you don't want to have to recreate the virtual machine every time you
 can use `BEAKER_DESTROY=no` and `BEAKER_PROVISION=no`. On the first run you will
 at least need `BEAKER_PROVISION` set to yes (the default). The Vagrantfile
-for the created virtual machines will be in `.vagrant/beaker_vagrant_fies`.
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.
 
 # vim: syntax=markdown

--- a/spec/defines/nexus_spec.rb
+++ b/spec/defines/nexus_spec.rb
@@ -152,4 +152,34 @@ describe 'archive::nexus' do
 
     it { is_expected.to compile.and_raise_error(%r{parameter 'allow_insecure' expects a value of type Undef or Boolean, got String}) }
   end
+  context 'nexus archive with use_nexus3_urls => false' do
+    let(:title) { '/tmp/artifact.war' }
+
+    let(:params) do
+      {
+        url: 'https://oss.sonatype.org',
+        gav: 'io.hawt:hawtio-web:1.4.36',
+        repository: 'releases',
+        packaging: 'war',
+        use_nexus3_urls: false
+      }
+    end
+
+    it { is_expected.to contain_archive('/tmp/artifact.war').with_source('https://oss.sonatype.org/service/local/artifact/maven/content?g=io.hawt&a=hawtio-web&v=1.4.36&r=releases&p=war') }
+  end
+  context 'nexus archive with use_nexus3_urls => true' do
+    let(:title) { '/tmp/artifact.war' }
+
+    let(:params) do
+      {
+        url: 'https://oss.sonatype.org',
+        gav: 'io.hawt:hawtio-web:1.4.36',
+        repository: 'releases',
+        packaging: 'war',
+        use_nexus3_urls: true
+      }
+    end
+
+    it { is_expected.to contain_archive('/tmp/artifact.war').with_source('https://oss.sonatype.org/repository/releases/io/hawt/hawtio-web/1.4.36/hawtio-web-1.4.36.war') }
+  end
 end


### PR DESCRIPTION
Nexus 3 no longer supports the old url format.
