### PR TITLE
Log actual and expected checksums on mismatch

### DIFF
--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -189,7 +189,10 @@ Puppet::Type.type(:archive).provide(:ruby) do
     # conditionally verify checksum:
     if resource[:checksum_verify] == :true && resource[:checksum_type] != :none
       archive = PuppetX::Bodeco::Archive.new(temppath)
-      raise(Puppet::Error, 'Download file checksum mismatch') unless archive.checksum(resource[:checksum_type]) == checksum
+      actual_checksum = archive.checksum(resource[:checksum_type])
+      if actual_checksum != checksum
+        raise(Puppet::Error, "Download file checksum mismatch (expected: #{checksum} actual: #{actual_checksum})")
+      end
     end
 
     move_file_in_place(temppath, archive_filepath)


### PR DESCRIPTION
Without this patch, updating Jenkins plugins is difficult because it
isn't clear what the actual checksum of the downloaded package is.  The
end user may discover the checksum by running puppet in debug mode,
discovering the curl command used to download the jenkins plugin, run
the command manually, then compute the checksum manually.

This patch helps the user by displaying the actual and expected
checksums when comparing them.  This allows the user to copy and paste
the actual checksum when updating hiera with the expected checksum.

Example
===

```
Error: Download file checksum mismatch (expected: 67051eb6df486e3639ad19bd9a46f43d19aec506 actual: beecec5ab3321c68ad5cce76ceacc14357c4da88)
Error: /Stage[main]/Jenkins::Plugins/Jenkins::Plugin[pipeline-model-api]/Archive[pipeline-model-api.hpi]/ensure: change from absent to present failed: Download file checksum
 mismatch (expected: 67051eb6df486e3639ad19bd9a46f43d19aec506 actual: beecec5ab3321c68ad5cce76ceacc14357c4da88)
```