### PR TITLE
Fix puppetmaster issue with parent loading in multiple environments

### DIFF
--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -1,4 +1,6 @@
-Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
+require_relative './ruby'
+
+Puppet::Type.type(:archive).provide(:curl, parent: Puppet::Type::Archive::ProviderRuby) do
   commands curl: 'curl'
   defaultfor feature: :posix
 

--- a/lib/puppet/provider/archive/wget.rb
+++ b/lib/puppet/provider/archive/wget.rb
@@ -1,4 +1,6 @@
-Puppet::Type.type(:archive).provide(:wget, parent: :ruby) do
+require_relative './ruby'
+
+Puppet::Type.type(:archive).provide(:wget, parent: Puppet::Type::Archive::ProviderRuby) do
   commands wget: 'wget'
 
   def wget_params(params)


### PR DESCRIPTION
After a restart, the puppetmaster was (sometimes) unable to load the child providers because the parent provider was unknown. This commit fixes this issue.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
