### PR TITLE
Fix typo in digest_type: sh256 -> sha256

### DIFF
--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -185,12 +185,12 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:checksum_type) do
-    desc 'archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512).'
+    desc 'archive file checksum type (none|md5|sha1|sha2|sha256|sha384|sha512).'
     newvalues(:none, :md5, :sha1, :sha2, :sha256, :sha384, :sha512)
     defaultto(:none)
   end
   newparam(:digest_type) do
-    desc 'archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512)
+    desc 'archive file checksum type (none|md5|sha1|sha2|sha256|sha384|sha512)
     (this parameter is camptocamp/archive compatibility).'
     newvalues(:none, :md5, :sha1, :sha2, :sha256, :sha384, :sha512)
     munge do |val|

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -35,7 +35,7 @@ define archive::download (
   Boolean                       $checksum         = true,
   Optional[String]              $digest_url       = undef,
   Optional[String]              $digest_string    = undef,
-  Optional[Enum['none', 'md5', 'sha1', 'sha2','sh256', 'sha384', 'sha512']] $digest_type      = 'md5',   # bad default!
+  Optional[Enum['none', 'md5', 'sha1', 'sha2','sha256', 'sha384', 'sha512']] $digest_type      = 'md5',   # bad default!
   Integer                       $timeout          = 120,     # ignored
   Stdlib::Compat::Absolute_path $src_target       = '/usr/src',
   Boolean                       $allow_insecure   = false,

--- a/manifests/nexus.pp
+++ b/manifests/nexus.pp
@@ -23,7 +23,7 @@ define archive::nexus (
   String            $gav,
   String            $repository,
   Enum['present', 'absent'] $ensure  = present,
-  Enum['none', 'md5', 'sha1', 'sha2','sh256', 'sha384', 'sha512'] $checksum_type   = 'md5',
+  Enum['none', 'md5', 'sha1', 'sha2','sha256', 'sha384', 'sha512'] $checksum_type   = 'md5',
   Boolean           $checksum_verify = true,
   String            $packaging       = 'jar',
   Boolean           $use_nexus3_urls = false,


### PR DESCRIPTION
Seems like this has been messed up [in the process of converting this module to Puppet 4 data types](https://github.com/voxpupuli/puppet-archive/commit/29f9ca7eca29e97fb9cd98aabc097c005471fbae#diff-ef311d40fc18cb5ad8d1a2bdbb03b69bR38). Also note that [camptocamp/archive has the correct digest name](https://github.com/camptocamp/puppet-archive/blob/master/manifests/download.pp#L82).