### PR TITLE
Don't glob archive URL with curl

### DIFF
--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
         resource[:source],
         '-o',
         filepath,
-        '-fsSL',
+        '-fsSLg',
         '--max-redirs',
         5
       ]
@@ -32,7 +32,7 @@ Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
     params = curl_params(
       [
         resource[:checksum_url],
-        '-fsSL',
+        '-fsSLg',
         '--max-redirs',
         5
       ]

--- a/spec/unit/puppet/provider/archive/curl_spec.rb
+++ b/spec/unit/puppet/provider/archive/curl_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe curl_provider do
         'http://home.lan/example.zip',
         '-o',
         String,
-        '-fsSL',
+        '-fsSLg',
         '--max-redirs',
         5
       ]
@@ -135,7 +135,7 @@ RSpec.describe curl_provider do
         let(:curl_params) do
           [
             'http://example.com/checksum',
-            '-fsSL',
+            '-fsSLg',
             '--max-redirs',
             5
           ]


### PR DESCRIPTION
Allows IPv6 IP addresses to be used wraped in square
brackets.

See https://bugs.launchpad.net/tripleo/+bug/1754065