### PR TITLE
do not escape path on windows for unzip command

### DIFF
--- a/lib/puppet_x/bodeco/archive.rb
+++ b/lib/puppet_x/bodeco/archive.rb
@@ -7,7 +7,11 @@ module PuppetX
     class Archive
       def initialize(file)
         @file = file
-        @file_path = Shellwords.shellescape file
+        if Facter.value(:osfamily) == 'windows'
+          @file_path = file
+        else
+          @file_path = Shellwords.shellescape file
+        end
       end
 
       def checksum(type)

--- a/lib/puppet_x/bodeco/archive.rb
+++ b/lib/puppet_x/bodeco/archive.rb
@@ -7,11 +7,11 @@ module PuppetX
     class Archive
       def initialize(file)
         @file = file
-        if Facter.value(:osfamily) == 'windows'
-          @file_path = file
-        else
-          @file_path = Shellwords.shellescape file
-        end
+        @file_path =  if Facter.value(:osfamily) == 'windows'
+                        '"' + file + '"'
+                      else
+                        Shellwords.shellescape file
+                      end
       end
 
       def checksum(type)

--- a/spec/unit/puppet_x/bodeco/archive_spec.rb
+++ b/spec/unit/puppet_x/bodeco/archive_spec.rb
@@ -78,15 +78,15 @@ describe PuppetX::Bodeco::Archive do
 
     tar = described_class.new('test.tar.gz')
     tar.stubs(:win_7zip).returns('7z.exe')
-    expect(tar.send(:command, :undef)).to eq '7z.exe x -aoa test.tar.gz'
-    expect(tar.send(:command, 'x -aot')).to eq '7z.exe x -aot test.tar.gz'
+    expect(tar.send(:command, :undef)).to eq '7z.exe x -aoa "test.tar.gz"'
+    expect(tar.send(:command, 'x -aot')).to eq '7z.exe x -aot "test.tar.gz"'
 
     zip = described_class.new('test.zip')
     zip.stubs(:win_7zip).returns('7z.exe')
-    expect(zip.send(:command, :undef)).to eq '7z.exe x -aoa test.zip'
+    expect(zip.send(:command, :undef)).to eq '7z.exe x -aoa "test.zip"'
 
-    zip = described_class.new('C:/Program Files/test.zip')
+    zip = described_class.new('C:/Program Files/test+xy.zip')
     zip.stubs(:win_7zip).returns('7z.exe')
-    expect(zip.send(:command, :undef)).to eq '7z.exe x -aoa C:/Program\ Files/test.zip'
+    expect(zip.send(:command, :undef)).to eq '7z.exe x -aoa "C:/Program Files/test+xyzip"'
   end
 end

--- a/spec/unit/puppet_x/bodeco/archive_spec.rb
+++ b/spec/unit/puppet_x/bodeco/archive_spec.rb
@@ -85,8 +85,8 @@ describe PuppetX::Bodeco::Archive do
     zip.stubs(:win_7zip).returns('7z.exe')
     expect(zip.send(:command, :undef)).to eq '7z.exe x -aoa "test.zip"'
 
-    zip = described_class.new('C:/Program Files/test+xy.zip')
+    zip = described_class.new('C:/Program Files/test.zip')
     zip.stubs(:win_7zip).returns('7z.exe')
-    expect(zip.send(:command, :undef)).to eq '7z.exe x -aoa "C:/Program Files/test+xyzip"'
+    expect(zip.send(:command, :undef)).to eq '7z.exe x -aoa "C:/Program Files/test.zip"'
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

#### Pull Request (PR) description

    Shellwords.shellescape does a bash style escape for invalid shell chars. On a windows pathname, it will inject invalid path char \ (which is a path separator on windows) into the path name being decompressed, which causes a failure in the decompress command. This change simply doesn't escape the


#### This Pull Request (PR) fixes the following issues

    Fixes #343
