### PR TITLE
Put the cookie option at the end when using curl

### DIFF
--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -5,10 +5,10 @@ Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
   def curl_params(params)
     account = [resource[:username], resource[:password]].compact.join(':') if resource[:username]
     params += optional_switch(account, ['--user', '%s'])
-    params += optional_switch(resource[:cookie], ['--cookie', '%s'])
     params += optional_switch(resource[:proxy_server], ['--proxy', '%s'])
     params += ['--insecure'] if resource[:allow_insecure]
     params += resource[:download_options] if resource[:download_options]
+    params += optional_switch(resource[:cookie], ['--cookie', '%s'])
 
     params
   end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
When using curl to download, the --cookie option is currently put in first before --proxy or --insecure options. Sometimes, the content of cookie can broke all command put after (discover with the module puppetlabs/puppetlabs-java when you use the class java::oracle).
So I just change the options order to make it work.

#### This Pull Request (PR) fixes the following issues
No issue open