### PR TITLE
Fallback to PowerShell for zip files on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cleanup. The benefits over existing modules such as
 * Follows 302 redirect and propagate download failure.
 * Optional checksum verification of archive files.
 * Automatic dependency to parent directory.
-* Support Windows file extraction via 7zip.
+* Support Windows file extraction via 7zip or PowerShell (Zip file only).
 * Able to cleanup archive files after extraction.
 
 This module is compatible with [camptocamp/archive](https://forge.puppet.com/camptocamp/archive).
@@ -48,9 +48,12 @@ For this it provides compatibility shims.
 
 ## Setup
 
-The module requires 7zip for windows clients which is installed via `include
-'::archive'`. On posix systems, curl is the default provider. The default
-provider can be overwritten by configuring resource defaults in site.pp:
+On Windows 7zip is required to extract all archives except zip files which will
+be extracted with PowerShell if 7zip is not available (requires 
+`System.IO.Compression.FileSystem`/Windows 2012+). Windows clients can install
+7zip via `include '::archive'`. On posix systems, curl is the default provider. 
+The default provider can be overwritten by configuring resource defaults in 
+site.pp:
 
 ```puppet
 Archive {

--- a/lib/puppet_x/bodeco/archive.rb
+++ b/lib/puppet_x/bodeco/archive.rb
@@ -65,6 +65,36 @@ module PuppetX
           'C:\\Program Files\\7-Zip\\7z.exe'
         elsif File.directory?('C:\\Program Files (x86)\\7-zip')
           'C:\\Program Files (x86)\\7-Zip\\7z.exe'
+        elsif @file_path =~ %r{.zip"$}
+          # Fallback to powershell for zipfiles - this works with windows
+          # 2012+ if your powershell/.net is too old the script will fail
+          # on execution and ask user to install 7zip.
+          # We have to manually extract each entry in the zip file
+          # to ensure we extract fresh copy because `ExtractToDirectory`
+          # method does not support overwriting
+          ps = <<-END
+          try {
+              Add-Type -AssemblyName System.IO.Compression.FileSystem -erroraction "silentlycontinue"
+              $zipFile = [System.IO.Compression.ZipFile]::openread(#{@file_path})
+              foreach ($zipFileEntry in $zipFile.Entries) {
+                  $pwd = (Get-Item -Path ".\" -Verbose).FullName
+                  $outputFile = [io.path]::combine($pwd, $zipFileEntry.FullName)
+                  $dir = ([io.fileinfo]$outputFile).DirectoryName
+
+                  if (-not(Test-Path -type Container -path $dir)) {
+                      mkdir $dir
+                  }
+                  if ($zipFileEntry.Name -ne "") {
+                      write-host "[extract] $zipFileEntry.Name"
+                      [System.IO.Compression.ZipFileExtensions]::ExtractToFile($zipFileEntry, $outputFile, $true)
+                  }
+              }
+          } catch [System.invalidOperationException] {
+              write-error "Your OS does not support System.IO.Compression.FileSystem - please install 7zip"
+          }
+          END
+
+          "powershell -command #{ps.gsub(%r{"}, '\\"').gsub(%r{\n}, '; ')}"
         else
           raise Exception, '7z.exe not available'
         end
@@ -73,7 +103,8 @@ module PuppetX
       def command(options)
         if Facter.value(:osfamily) == 'windows'
           opt = parse_flags('x -aoa', options, '7z')
-          "#{win_7zip} #{opt} #{@file_path}"
+          cmd = win_7zip
+          cmd =~ %r{7z.exe} ? "#{cmd} #{opt} #{@file_path}" : cmd
         else
           case @file
           when %r{\.tar$}

--- a/spec/unit/puppet_x/bodeco/archive_spec.rb
+++ b/spec/unit/puppet_x/bodeco/archive_spec.rb
@@ -88,5 +88,9 @@ describe PuppetX::Bodeco::Archive do
     zip = described_class.new('C:/Program Files/test.zip')
     zip.stubs(:win_7zip).returns('7z.exe')
     expect(zip.send(:command, :undef)).to eq '7z.exe x -aoa "C:/Program Files/test.zip"'
+
+    zip = described_class.new('C:/Program Files/test.zip')
+    zip.stubs(:win_7zip).returns('powershell')
+    expect(zip.send(:command, :undef)).to eq 'powershell'
   end
 end


### PR DESCRIPTION
Since most users on Windows are going to be using zip files and might not be able to easily install 7zip, how about this approach for using PowerShell/.net built-in support to for zip files to do the extract when there is no 7zip rather then failing? 


~~~
For Windows since 2012, it is possible to extract zip files (only) using
`System.IO.Compression.FileSystem`. For systems where 7zip is not
available, use an inline powershell script to perform the extact. 7zip
will still be used in preference, if available.
