### PR TITLE
Bump stdlib dependency to <6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -90,7 +90,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ]
 }


### PR DESCRIPTION

#### Pull Request (PR) description

Due to the new stdlib release of 5.0.0, this needs it's dependency bumped to < 6.0.0. We also will need a release of this module to fix breakages being seen in other modules.

#### This Pull Request (PR) fixes the following issues

This is the error we are getting on java:
`An error occurred while loading ./spec/acceptance/install_spec.rb.
Failure/Error: install_module_dependencies_on(hosts)
Beaker::Host::CommandFailure:
  Host 'ubuntu-1404-x64' exited with 1 running:
   puppet module install puppet-archive -v 3.1.1
  Last 10 lines of output were:
  	Notice: Preparing to install into /etc/puppetlabs/code/environments/production/modules ...
  	Notice: Downloading from https://forgeapi.puppet.com ...
  	Error: Could not install module 'puppet-archive' (???)
  	  No version of 'puppet-archive' can satisfy all dependencies
  	    Use `puppet module install --ignore-dependencies` to install only this module`

