### PR TITLE
Allow `puppetlabs/stdlib` 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -90,7 +90,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.18.0 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
stdlib 6.0.0 is due to be released soon.
This module has already dropped support for puppet 4 and/or doesn't
use the updated stdlib `merge` function.

See
https://github.com/puppetlabs/puppetlabs-stdlib/blob/217068f97edd2396ce37ac8c1bd7e23da621d6be/CHANGELOG.md#supported-release-600