### PR TITLE
add bunzip2 filetype support

### DIFF
--- a/lib/puppet_x/bodeco/archive.rb
+++ b/lib/puppet_x/bodeco/archive.rb
@@ -140,6 +140,9 @@ module PuppetX
           when %r{(\.zip|\.war|\.jar)$}
             opt = parse_flags('-o', options, 'zip')
             "unzip #{opt} #{@file_path}"
+          when %r{(\.bz2)$}
+            opt = parse_flags('-d', options, 'bunzip2')
+            "bunzip2 #{opt} #{@file_path}"
           else
             raise NotImplementedError, "Unknown filetype: #{@file}"
           end

--- a/spec/unit/puppet_x/bodeco/archive_spec.rb
+++ b/spec/unit/puppet_x/bodeco/archive_spec.rb
@@ -39,6 +39,8 @@ describe PuppetX::Bodeco::Archive do
     expect(tar.send(:command, :undef)).to eq 'unxz -dc test.tar.xz | tar xf -'
     gunzip = described_class.new('test.gz')
     expect(gunzip.send(:command, :undef)).to eq 'gunzip -d test.gz'
+    bunzip2 = described_class.new('test.bz2')
+    expect(bunzip2.send(:command, :undef)).to eq 'bunzip2 -d test.bz2'
     zip = described_class.new('test.zip')
     expect(zip.send(:command, :undef)).to eq 'unzip -o test.zip'
     expect(zip.send(:command, '-a')).to eq 'unzip -a test.zip'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

When a `bz2` is used by module we have the message ` Unknown filetype`.

This PR bz2 in known file types.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
