### PR TITLE
Use `relative_require` in artifactory functions

### DIFF
--- a/lib/puppet/functions/archive/artifactory_checksum.rb
+++ b/lib/puppet/functions/archive/artifactory_checksum.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'puppet_x/bodeco/util'
+require_relative '../../../puppet_x/bodeco/util.rb'
 
 Puppet::Functions.create_function(:'archive::artifactory_checksum') do
   # @summary A function that returns the checksum value of an artifact stored in Artifactory

--- a/lib/puppet/functions/archive/artifactory_latest_url.rb
+++ b/lib/puppet/functions/archive/artifactory_latest_url.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'puppet_x/bodeco/util'
+require_relative '../../../puppet_x/bodeco/util.rb'
 
 Puppet::Functions.create_function(:'archive::artifactory_latest_url') do
   dispatch :artifactory_latest_url do

--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -14,7 +14,7 @@ module PuppetX
       end
 
       #
-      # This allows you to use a puppet syntax for a file and return it's content.
+      # This allows you to use a puppet syntax for a file and return its content.
       #
       # @example
       #  puppet_download 'puppet:///modules/my_module_name/my_file.dat


### PR DESCRIPTION
This doesn't seem to have been neccessary for all users and probably
depends on how puppetserver has `ruby-load-path` configured.
See https://tickets.puppetlabs.com/browse/SERVER-973?focusedCommentId=224547&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-224547

Requiring the library using an absolute path should help
https://tickets.puppetlabs.com/browse/SERVER-973?focusedCommentId=352751&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-352751

Note, any changes to util.rb will still result in horrible environment
isolation issues.  A full fix would involve implementing
@trevor-vaughan's complete metaprogramming solution documented here.
https://www.onyxpoint.com/fixing-the-client-side-of-multi-tenancy-in-the-puppet-server

util.rb is somewhat more complicated than the example demonstrated, so
I've left that well alone for now.

Fixes #320