### PR TITLE
Convert `archive` class docs to puppet-strings and small README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Archive {
 }
 ```
 
-Users of the module is responsbile for archive package dependencies for
+Users of the module are responsible for archive package dependencies, for
 alternative providers and all extraction utilities such as tar, gunzip, bunzip:
 
 ```puppet
@@ -83,9 +83,9 @@ if $facts['osfamily'] != 'windows' {
 
 ## Usage
 
-Archive module dependency is managed by the archive class. This is only
-required for windows platform. By default 7zip is installed via chocolatey, but
-can be adjusted to use the msi package instead:
+Archive module dependencies are managed by the `archive` class. This is only
+required on Windows. By default 7zip is installed via chocolatey, but
+the MSI package can be installed instead:
 
 ```puppet
 class { 'archive':
@@ -276,10 +276,8 @@ archive { '/var/lib/example.zip':
 
 ### S3 bucket
 
-S3 support is implemented via the [AWS
-CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html).
-By default this dependency is only installed for Linux VMs running on AWS, or
-enabled via `aws_cli_install` option:
+S3 support is implemented via the [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html).
+On non-Windows systems, the `archive` class will install this dependency when the `aws_cli_install` parameter is set to `true`:
 
 ```puppet
 class { 'archive':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,30 +1,34 @@
-# Class: archive
-# ==============
+# @summary Manages archive module's dependencies.
 #
-# Manages archive modules dependencies.
+# @example On Windows, ensure 7zip is installed using the default `chocolatey` provider.
+#   include archive
 #
-# Parameters
-# ----------
+# @example On Windows, install a 7zip MSI with the native `windows` package provider.
+#   class { 'archive':
+#     seven_zip_name     => '7-Zip 9.20 (x64 edition)',
+#     seven_zip_source   => 'C:/Windows/Temp/7z920-x64.msi',
+#     seven_zip_provider => 'windows',
+#   }
 #
-# * seven_zip_name: 7zip package name.
-# * seven_zip_provider: 7zip package provider (accepts windows/chocolatey).
-# * seven_zip_source: alternative package source.
-# * aws_cli_install: install aws cli command (default: false).
+# @example Install the AWS CLI tool. (Not supported on Windows).
+#   class { 'archive':
+#     aws_cli_install => true,
+#   }
 #
-# Examples
-# --------
-#
-# class { 'archive':
-#   seven_zip_name     => '7-Zip 9.20 (x64 edition)',
-#   seven_zip_source   => 'C:/Windows/Temp/7z920-x64.msi',
-#   seven_zip_provider => 'windows',
-# }
+# @param seven_zip_name
+#   7zip package name.  This parameter only applies to Windows.
+# @param seven_zip_provider
+#   7zip package provider.  This parameter only applies to Windows where it defaults to `chocolatey`. Can be set to an empty string, (or `undef` via hiera), if you don't want this module to manage 7zip.
+# @param seven_zip_source
+#   Alternative package source for 7zip.  This parameter only applies to Windows.
+# @param aws_cli_install
+#   Installs the AWS CLI command needed for downloading from S3 buckets.  This parameter is currently not implemented on Windows.
 #
 class archive (
-  Optional[String] $seven_zip_name     = $archive::params::seven_zip_name,
-  Optional[String] $seven_zip_provider = $archive::params::seven_zip_provider,
-  Optional[String] $seven_zip_source   = undef,
-  Boolean          $aws_cli_install    = false,
+  Optional[String[1]]                       $seven_zip_name     = $archive::params::seven_zip_name,
+  Optional[Enum['chocolatey','windows','']] $seven_zip_provider = $archive::params::seven_zip_provider,
+  Optional[String[1]]                       $seven_zip_source   = undef,
+  Boolean                                   $aws_cli_install    = false,
 ) inherits archive::params {
 
   if $facts['os']['family'] == 'Windows' and !($seven_zip_provider in ['', undef]) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,12 +1,9 @@
-# Class: archive::params
-# ======================
-#
-# archive settings such as default user and file mode.
-#
+# @summary OS specific `archive` settings such as default user and file mode.
+# @api private
 class archive::params {
   case $facts['os']['family'] {
     'Windows': {
-      $path               = $::archive_windir
+      $path               = $facts['archive_windir']
       $owner              = 'S-1-5-32-544' # Adminstrators
       $group              = 'S-1-5-18'     # SYSTEM
       $mode               = '0640'


### PR DESCRIPTION
Also improve related documentation in README.