### PR TITLE
Use curl netrc file instead of `--user`

### DIFF
--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -1,16 +1,35 @@
+require 'uri'
+require 'tempfile'
+
 Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
   commands curl: 'curl'
   defaultfor feature: :posix
 
   def curl_params(params)
-    account = [resource[:username], resource[:password]].compact.join(':') if resource[:username]
-    params += optional_switch(account, ['--user', '%s'])
+    if resource[:username]
+      create_netrcfile
+      params += ['--netrc-file', @netrc_file.path]
+    end
     params += optional_switch(resource[:proxy_server], ['--proxy', '%s'])
     params += ['--insecure'] if resource[:allow_insecure]
     params += resource[:download_options] if resource[:download_options]
     params += optional_switch(resource[:cookie], ['--cookie', '%s'])
 
     params
+  end
+
+  def create_netrcfile
+    @netrc_file = Tempfile.new('.puppet_archive_curl')
+    machine = URI.parse(resource[:source]).host
+    @netrc_file.write("machine #{machine}\nlogin #{resource[:username]}\npassword #{resource[:password]}\n")
+    @netrc_file.close
+  end
+
+  def delete_netrcfile
+    return if @netrc_file.nil?
+
+    @netrc_file.unlink
+    @netrc_file = nil
   end
 
   def download(filepath)
@@ -25,7 +44,11 @@ Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
       ]
     )
 
-    curl(params)
+    begin
+      curl(params)
+    ensure
+      delete_netrcfile
+    end
   end
 
   def remote_checksum
@@ -38,6 +61,10 @@ Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
       ]
     )
 
-    curl(params)[%r{\b[\da-f]{32,128}\b}i]
+    begin
+      curl(params)[%r{\b[\da-f]{32,128}\b}i]
+    ensure
+      delete_netrcfile
+    end
   end
 end


### PR DESCRIPTION
This stops credentials appearing in the process list and failed
downloads won't result in the credentials being logged in puppet reports
and agent log output.

Fixes #397