### PR TITLE
No need for Augeas PPA on bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@
 dist: bionic
 language: ruby
 cache: bundler
-addons:
-  apt:
-    sources:
-      - augeas
-    packages:
-      - libaugeas-dev
 before_install:
   - yes | gem update --system
   - bundle --version


### PR DESCRIPTION
Ubuntu Bionic has Augeas 1.10 already available, so there is no need to use the Augeas PPA (which provides Augeas 1.16)