### PR TITLE
Clean up temporary files when checksums don't match

### DIFF
--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -191,6 +191,7 @@ Puppet::Type.type(:archive).provide(:ruby) do
       archive = PuppetX::Bodeco::Archive.new(temppath)
       actual_checksum = archive.checksum(resource[:checksum_type])
       if actual_checksum != checksum
+        destroy(temppath)
         raise(Puppet::Error, "Download file checksum mismatch (expected: #{checksum} actual: #{actual_checksum})")
       end
     end


### PR DESCRIPTION
Noticed that the archive module was leaving behind quite a few files in /tmp when there were checksum mismatches.

This ensures that the temporary files will be cleaned up before throwing an error.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This pull request removes the temporary files created by the archive module if the checksum fails to match. Previously, the module would throw an error and leave the temporary file in /tmp.

