### PR TITLE
Add support param $temp_dir in archive::nexus

### DIFF
--- a/manifests/nexus.pp
+++ b/manifests/nexus.pp
@@ -44,6 +44,8 @@ define archive::nexus (
   Optional[String]  $proxy_server    = undef,
   Optional[String]  $proxy_type      = undef,
   Optional[Boolean] $allow_insecure  = undef,
+  Optional[String]  $proxy_type      = undef,
+  Optional[String]  $temp_dir        = undef,
 ) {
   include archive::params
 
@@ -107,6 +109,7 @@ define archive::nexus (
     proxy_server    => $proxy_server,
     proxy_type      => $proxy_type,
     allow_insecure  => $allow_insecure,
+    temp_dir        => $temp_dir,
   }
 
   $file_owner = pick($owner, $archive::params::owner)


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Add support param $temp_dir in archive::nexus.
This param support in ::archive. It changes default file temporary storage location while it in downloading process
It can be useful when you download file from Nexus. And this file is too large and there is not enough space in the default temp directory to temporarily store it.
-->

#### This Pull Request (PR) fixes the following issues
<!--
n/a
-->
