### PR TITLE
Support for cacert_file param on archive resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ archive { '/tmp/staging/master.zip':
 * `source`: archive file source, supports http|https|ftp|file|s3|gs uri.
 * `username`: username to download source file.
 * `password`: password to download source file.
+* `cacert_file`: Path to a CA certificate bundle.
 * `allow_insecure`: Ignore HTTPS certificate errors (true|false). (default: false)
 * `cookie`: archive file download cookie.
 * `checksum_type`: archive file checksum type (none|md5|sha1|sha2|sha256|sha384|

--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -14,6 +14,7 @@ Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
     params += ['--insecure'] if resource[:allow_insecure]
     params += resource[:download_options] if resource[:download_options]
     params += optional_switch(resource[:cookie], ['--cookie', '%s'])
+    params += optional_switch(resource[:cacert_file], ['--cacert', '%s'])
 
     params
   end

--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -217,7 +217,8 @@ Puppet::Type.type(:archive).provide(:ruby) do
       cookie: resource[:cookie],
       proxy_server: resource[:proxy_server],
       proxy_type: resource[:proxy_type],
-      insecure: resource[:allow_insecure]
+      insecure: resource[:allow_insecure],
+      cacert_file: resource[:cacert_file]
     )
   end
 

--- a/lib/puppet/provider/archive/wget.rb
+++ b/lib/puppet/provider/archive/wget.rb
@@ -8,6 +8,7 @@ Puppet::Type.type(:archive).provide(:wget, parent: :ruby) do
     params += optional_switch(resource[:proxy_server], ['-e use_proxy=yes', "-e #{resource[:proxy_type]}_proxy=#{resource[:proxy_server]}"])
     params += ['--no-check-certificate'] if resource[:allow_insecure]
     params += resource[:download_options] if resource[:download_options]
+    params += optional_switch(resource[:cacert_file], ['--ca-certificate=%s'])
 
     params
   end

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -237,7 +237,7 @@ Puppet::Type.newtype(:archive) do
   newparam(:cacert_file) do
     desc 'path to a custom CA certificate bundle file'
     validate do |value|
-      unless !value.nil? && Puppet::Util.absolute_path?(value)
+      if !value.nil? && !Puppet::Util.absolute_path?(value)
         raise ArgumentError, "cacert_file must be absolute: #{value}"
       end
     end

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -234,6 +234,15 @@ Puppet::Type.newtype(:archive) do
     defaultto :false
   end
 
+  newparam(:cacert_file) do
+    desc 'path to a custom CA certificate bundle file'
+    validate do |value|
+      unless !value.nil? && Puppet::Util.absolute_path?(value)
+        raise ArgumentError, "cacert_file must be absolute: #{value}"
+      end
+    end
+  end
+
   newparam(:download_options) do
     desc 'provider download options (affects curl, wget, gs, and only s3 downloads for ruby provider)'
 

--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -85,7 +85,7 @@ module PuppetX
                        elsif ENV.key?('SSL_CERT_FILE')
                          ENV['SSL_CERT_FILE']
                        elsif Facter.value(:osfamily) == 'windows'
-                         File.expand_path(File.join(__FILE__, '..', 'cacert.pem'))
+                         File.join(__dir__, 'cacert.pem')
                        end
       end
 

--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -80,7 +80,13 @@ module PuppetX
           @proxy_port = uri.port
         end
 
-        ENV['SSL_CERT_FILE'] = File.expand_path(File.join(__FILE__, '..', 'cacert.pem')) if Facter.value(:osfamily) == 'windows' && !ENV.key?('SSL_CERT_FILE')
+        @cacert_file = if options.key?[:cacert_file]
+                         options[:cacert_file]
+                       elsif ENV.key?('SSL_CERT_FILE')
+                         ENV['SSL_CERT_FILE']
+                       elsif Facter.value(:osfamily) == 'windows'
+                         File.expand_path(File.join(__FILE__, '..', 'cacert.pem'))
+                       end
       end
 
       def generate_request(uri)
@@ -98,6 +104,9 @@ module PuppetX
                     else
                       { use_ssl: false }
                     end
+
+        http_opts[:ca_file] = @cacert_file unless @cacert_file.nil?
+
         Net::HTTP.start(uri.host, uri.port, @proxy_addr, @proxy_port, http_opts) do |http|
           http.request(generate_request(uri)) do |response|
             case response

--- a/spec/unit/puppet/provider/archive/curl_spec.rb
+++ b/spec/unit/puppet/provider/archive/curl_spec.rb
@@ -169,5 +169,20 @@ RSpec.describe curl_provider do
         expect(provider).to have_received(:curl).with(default_options << '--tlsv1')
       end
     end
+
+    context 'using cacert_file' do
+      let(:resource_properties) do
+        {
+          name: name,
+          source: 'http://home.lan/example.zip',
+          cacert_file: '/custom-ca-bundle.pem'
+        }
+      end
+
+      it 'calls curl with --cacert' do
+        provider.download(name)
+        expect(provider).to have_received(:curl).with(default_options << '--cacert' << '/custom-ca-bundle.pem')
+      end
+    end
   end
 end

--- a/spec/unit/puppet/provider/archive/wget_spec.rb
+++ b/spec/unit/puppet/provider/archive/wget_spec.rb
@@ -152,5 +152,21 @@ RSpec.describe wget_provider do
         end
       end
     end
+
+    context 'with cacert_file' do
+      let(:resource_properties) do
+        {
+          name: name,
+          source: 'http://home.lan/example.zip',
+          cacert_file: '/custom-ca-bundle.pem'
+        }
+      end
+
+      it 'calls wget with default options and --ca-certificate' do
+        provider.download(name)
+        expect(execution).to have_received(:execute).with([default_options, '--ca-certificate=/custom-ca-bundle.pem'].join(' '))
+      end
+    end
+
   end
 end

--- a/spec/unit/puppet/provider/archive/wget_spec.rb
+++ b/spec/unit/puppet/provider/archive/wget_spec.rb
@@ -167,6 +167,5 @@ RSpec.describe wget_provider do
         expect(execution).to have_received(:execute).with([default_options, '--ca-certificate=/custom-ca-bundle.pem'].join(' '))
       end
     end
-
   end
 end

--- a/spec/unit/puppet/type/archive_spec.rb
+++ b/spec/unit/puppet/type/archive_spec.rb
@@ -22,6 +22,7 @@ describe Puppet::Type.type(:archive) do
     it { expect(resource[:allow_insecure]).to eq false }
     it { expect(resource[:download_options]).to eq nil }
     it { expect(resource[:temp_dir]).to eq nil }
+    it { expect(resource[:cacert_file]).to eq nil }
   end
 
   it 'verify resource[:path] is absolute filepath' do
@@ -34,6 +35,12 @@ describe Puppet::Type.type(:archive) do
     expect do
       resource[:temp_dir] = 'relative/file'
     end.to raise_error(Puppet::Error, %r{Invalid temp_dir})
+  end
+
+  it 'verify resource[:cacert_file] is absolute path' do
+    expect do
+      resource[:cacert_file] = 'relative/file'
+    end.to raise_error(Puppet::Error, %r{cacert_file must be absolute})
   end
 
   describe 'on posix', if: Puppet.features.posix? do


### PR DESCRIPTION
#### Pull Request (PR) description

This adds a cacert_file parameter to the archive type and
support for this option in curl, wget and ruby provider.

The option could be used to specify a custom CA bundle for
certificate verification in the TLS handshake.

#### This Pull Request (PR) fixes the following issues

related #400 
implements #188 

#### Additional notes

I'm unsure about the part in lib/puppet_x/bodeco/util.rb with ENV['SSL_CERT_FILE'].
Where is it used? Is it still required?