### PR TITLE
Windows: find 7zip binary

### DIFF
--- a/lib/puppet_x/bodeco/archive.rb
+++ b/lib/puppet_x/bodeco/archive.rb
@@ -65,6 +65,8 @@ module PuppetX
           'C:\\Program Files\\7-Zip\\7z.exe'
         elsif File.directory?('C:\\Program Files (x86)\\7-zip')
           'C:\\Program Files (x86)\\7-Zip\\7z.exe'
+        elsif system("where 7z.exe")
+          '7z.exe'
         elsif @file_path =~ %r{.zip"$}
           # Fallback to powershell for zipfiles - this works with windows
           # 2012+ if your powershell/.net is too old the script will fail


### PR DESCRIPTION

#### Pull Request (PR) description
Search for 7z.exe Binary if not installed in the standard Paths
