### PR TITLE
Drop support for CentOS/RHEL 6 and variants

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -11,7 +10,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -19,7 +17,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -27,9 +24,7 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
-        "7",
-        "8"
+        "7"
       ]
     },
     {


### PR DESCRIPTION
CentOS 6 is now EOL.

There's little reason to think this module won't continue to work for
some time, but this change is also a prerequisite for enabling
acceptance tests, (where it's no longer possible to test on CentOS 6)