### PR TITLE
Support stdlib 7.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -104,7 +104,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.18.0 < 7.0.0"
+      "version_requirement": ">= 4.18.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Stdlib now is at 7.0.0 and this module's pinning to < 7.0.0 is causing some of my modules acceptance tests to fail if I attempt to upgrade to latest stdlib.
