### PR TITLE
Fix Could not set 'present' on ensure: wrong number of arguments (given 1, expected 0)

### DIFF
--- a/lib/puppet/provider/archive/ruby.rb
+++ b/lib/puppet/provider/archive/ruby.rb
@@ -194,7 +194,8 @@ Puppet::Type.type(:archive).provide(:ruby) do
       archive = PuppetX::Bodeco::Archive.new(temppath)
       actual_checksum = archive.checksum(resource[:checksum_type])
       if actual_checksum != checksum
-        destroy(temppath)
+        destroy
+        FileUtils.rm_f(temppath) if File.exist?(temppath)
         raise(Puppet::Error, "Download file checksum mismatch (expected: #{checksum} actual: #{actual_checksum})")
       end
     end

--- a/spec/unit/puppet/provider/archive/ruby_spec.rb
+++ b/spec/unit/puppet/provider/archive/ruby_spec.rb
@@ -93,5 +93,35 @@ RSpec.describe ruby_provider do
         end
       end
     end
+
+    describe 'checksum match' do
+      let(:resource_properties) do
+        {
+          name: name,
+          source: '/dev/null',
+          checksum: 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+          checksum_type: 'sha1',
+        }
+      end
+
+      it 'does not raise an error' do
+        provider.transfer_download(name)
+      end
+    end
+
+    describe 'checksum mismatch' do
+      let(:resource_properties) do
+        {
+          name: name,
+          source: '/dev/null',
+          checksum: '9edf7cd9dfa0d83cd992e5501a480ea502968f15109aebe9ba2203648f3014db',
+          checksum_type: 'sha1',
+        }
+      end
+
+      it 'raises PuppetError (Download file checksum mismatch)' do
+        expect { provider.transfer_download(name) }.to raise_error(Puppet::Error, %r{Download file checksum mismatch})
+      end
+    end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Without this patch a mysterious exception is thrown when the checksum
does not match.  This is a problem because it's unclear the problem is
related to the checksum.

This patch fixes the problem by returning the correct error when the
checksum doesn't match.

#### This Pull Request (PR) fixes the following issues

```
Wrapped exception:
wrong number of arguments (given 1, expected 0)
/opt/puppetlabs/puppet/cache/lib/puppet/provider/archive/ruby.rb:86:in `destroy'
/opt/puppetlabs/puppet/cache/lib/puppet/provider/archive/ruby.rb:197:in `transfer_download'
/opt/puppetlabs/puppet/cache/lib/puppet/provider/archive/ruby.rb:81:in `create'
/opt/puppetlabs/puppet/cache/lib/puppet/type/archive.rb:13:in `block (3 levels) in <top (required)>'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/property.rb:490:in `set'
...
Error:
/Stage[main]/Profile::Consul::Consultemplate/Archive[/usr/local/bin/consul-template]/ensure:
change from 'absent' to 'present' failed: Could not set 'present' on
ensure: wrong number of arguments (given 1, expected 0) (file:
/etc/puppetlabs/code/environments/jeff/site-modules/profile/manifests/consul/consultemplate.pp,
line: 6)
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
<!--
Replace this comment with a description of your pull request.
-->

<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
