### PR TITLE
Drop Debian 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
         "10"
       ]
     },


### PR DESCRIPTION
Debian 9 went EoL  2020-07-06  per 
https://wiki.debian.org/DebianReleases
