### PR TITLE
Drop EoL AIX versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -71,8 +71,6 @@
     {
       "operatingsystem": "AIX",
       "operatingsystemrelease": [
-        "5.3",
-        "6.1",
         "7.1"
       ]
     },


### PR DESCRIPTION
Only 7.1 and 7.2 are still supported