### PR TITLE
Drop Virtuozzo 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -88,7 +88,6 @@
     {
       "operatingsystem": "VirtuozzoLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     }


### PR DESCRIPTION
6 went EoL Nov. 2019 according to
https://www.virtuozzo.com/all-supported-products/lifecycle-policies
