### PR TITLE
Fix `archive::download::digest_type` data type (reverts 6.0.0 breaking change)

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -35,7 +35,7 @@ define archive::download (
   Boolean                       $checksum         = true,
   Optional[String]              $digest_url       = undef,
   Optional[String]              $digest_string    = undef,
-  Optional[Enum['none', 'md5', 'sha1', 'sha2','sha256', 'sha384', 'sha512']] $digest_type      = 'md5',   # bad default!
+  Enum['none', 'md5', 'sha1', 'sha2','sha256', 'sha384', 'sha512'] $digest_type = 'md5',   # bad default!
   Integer                       $timeout          = 120,     # ignored
   Stdlib::Compat::Absolute_path $src_target       = '/usr/src',
   Boolean                       $allow_insecure   = false,


### PR DESCRIPTION
Reverts https://github.com/voxpupuli/puppet-archive/pull/449 and fixes #450 without creating a breaking change.

6.0.0 was released less than 12 hours ago, so if we get this into a 6.0.1 asap, I think we can prevent unnecessary pain for users.