### PR TITLE
Mark CentOS 9 and RHEL 9 as supported operating systems

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,4 @@
 fixtures:
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-    pe_gem: 'https://github.com/puppetlabs/puppetlabs-pe_gem.git'
     yardoc: 'https://github.com/Sharpie/puppet-puppet_yardoc.git'

--- a/metadata.json
+++ b/metadata.json
@@ -4,14 +4,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
#### Pull Request (PR) description
This adds CentOS 9 and RHEL 9 to supported operating systems.
These versions were released a while ago.

#### This Pull Request (PR) fixes the following issues
N/A
