### PR TITLE
Fix catalog compilation failure when net/ftp is not available

### DIFF
--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -145,9 +145,9 @@ module PuppetX
     end
 
     class FTP
-      require 'net/ftp'
-
       def initialize(url, options)
+        require 'net/ftp'
+
         uri = URI(url)
         username = options[:username]
         password = options[:password]


### PR DESCRIPTION
When net/ftp is not available, the archive module fail to load and the
PuppetServer catalog compilation fail.  While this gem is generally
available because part of the Ruby standard library, some flavors of
Ruby do noth ship with it by default, e.g. FreeBSD package of Ruby 3.2
or GitHub actions of Ruby 3.2.

Because the archive module has multiple ways to download files, the
absence of net/ftp is not necessarily an issue because when curl(1) is
available, it is preferred over net/ftp.  The catalog compilation error
is therefore not required.

Lazy load net/ftp when the pure-ruby download-over-FTP code is run, so
that the absence of net/ftp cause a resource evaluation error on the
agent side and the rest of the catalog still apply.

Fixes #488
