### PR TITLE
change part of the code for using aws cli v2

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,24 +59,24 @@ class archive (
       # Using bundled install option:
       # http://docs.aws.amazon.com/cli/latest/userguide/installing.html#install-bundle-other-os
 
-      file { '/opt/awscli-bundle':
+      file { '/opt/aws':
         ensure => 'directory',
       }
 
-      archive { 'awscli-bundle.zip':
+      archive { 'awscli-exe-linux-x86_64.zip':
         ensure       => present,
-        path         => '/opt/awscli-bundle/awscli-bundle.zip',
-        source       => 'https://s3.amazonaws.com/aws-cli/awscli-bundle.zip',
+        path         => '/opt/aws/awscli-exe-linux-x86_64.zip',
+        source       => 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip',
         extract      => true,
         extract_path => '/opt',
-        creates      => '/opt/awscli-bundle/install',
+        creates      => '/opt/aws/install',
         cleanup      => true,
       }
 
       exec { 'install_aws_cli':
-        command     => '/opt/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws',
+        command     => '/opt/aws/install -i /usr/local/aws-cli -b /usr/local/bin',
         refreshonly => true,
-        subscribe   => Archive['awscli-bundle.zip'],
+        subscribe   => Archive['awscli-exe-linux-x86_64.zip'],
       }
     }
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I suggest using newest version aws cli v2, according to documentation: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html

Also, current package version  have same problem due to end of support for Python 2.7: https://aws.amazon.com/ru/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/


