### PR TITLE
Avoid Dir.chdir by passing cwd to execute() and simplify %s detection in custom_command

### DIFF
--- a/lib/puppet_x/bodeco/archive.rb
+++ b/lib/puppet_x/bodeco/archive.rb
@@ -43,19 +43,17 @@ module PuppetX
 
         custom_command = opts.fetch(:custom_command, nil)
         options = opts.fetch(:options)
-        Dir.chdir(path) do
-          cmd = if custom_command&.include?('%s')
-                  custom_command % @file_path
-                elsif custom_command
-                  "#{custom_command} #{options} #{@file_path}"
-                else
-                  command(options)
-                end
+        cmd = if custom_command&.include?('%s')
+                custom_command % @file_path
+              elsif custom_command
+                "#{custom_command} #{options} #{@file_path}"
+              else
+                command(options)
+              end
 
-          Puppet.debug("Archive extracting #{@file} in #{path}: #{cmd}")
-          File.chmod(0o644, @file) if opts[:uid] || opts[:gid]
-          Puppet::Util::Execution.execute(cmd, uid: opts[:uid], gid: opts[:gid], failonfail: true, squelch: false, combine: true)
-        end
+        Puppet.debug("Archive extracting #{@file} in #{path}: #{cmd}")
+        File.chmod(0o644, @file) if opts[:uid] || opts[:gid]
+        Puppet::Util::Execution.execute(cmd, uid: opts[:uid], gid: opts[:gid], cwd: path, failonfail: true, squelch: false, combine: true)
       end
 
       private


### PR DESCRIPTION
The use of chdir is problematic in threaded environments (only one thread may chdir) and Puppet has a native method for this. See https://github.com/puppetlabs/puppet/pull/9387 for more information.

It also simplifies the detection of `%s` in `custom_command` by using the cheaper include? method. The safe operator makes it even shorter.